### PR TITLE
fix: revisione completa KPI — calcoli reali e metriche accurate

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -1034,16 +1034,16 @@ def get_kpi_dashboard():
 def get_admin_kpi():
     """Recupera KPI sistema per admin dashboard"""
     try:
-        # Ordini attivi (non SPEDITO)
+        from datetime import datetime as dt, timedelta
+
         all_orders = OrderManager.get_all_orders_dict()
-        active_orders = [o for o in all_orders if o.get('status') not in ('COMPLETATO', 'PARZIALE')]
+        active_orders = [o for o in all_orders if o.get('status') not in ('COMPLETATO', 'PARZIALE', 'SPEDITO')]
         ordini_attivi = len(active_orders)
 
-        # KPI operai
+        # KPI operai (calcoli reali, nessun mock)
         kpi_operai = AuditManager.get_kpi_operai()
 
-        # Calcola login oggi
-        from datetime import datetime as dt
+        # Login oggi
         today = dt.now().date()
         audit_logs = AuditManager.get_recent(limit=1000)
         login_oggi = len([
@@ -1051,16 +1051,21 @@ def get_admin_kpi():
             if log['action'] == 'LOGIN' and dt.fromisoformat(log['timestamp']).date() == today
         ])
 
-        # Calcola efficienza: ordini completati on-time vs totali
-        completed_orders = [o for o in all_orders if o.get('status') in ('COMPLETATO', 'PARZIALE')]
-        if completed_orders:
-            on_time = sum(1 for o in completed_orders if o.get('data_consegna') and dt.fromisoformat(o['data_consegna']).date() >= today)
-            efficienza = int((on_time / len(completed_orders)) * 100)
-        else:
-            efficienza = 0
+        # Efficienza: per ordini COMPLETATI, verifica se ultimo step <= data_consegna
+        # Usa il KPI dashboard che ha gia' il calcolo corretto
+        kpi_dashboard = KPIManager.get_dashboard_kpi()
+        efficienza = kpi_dashboard.get('riepilogo', {}).get('efficienza_puntualita', 0) if kpi_dashboard.get('success') else 0
 
         # Ritardi: ordini scaduti non completati
         ritardi = sum(1 for o in active_orders if o.get('data_consegna') and dt.fromisoformat(o['data_consegna']).date() < today)
+
+        # Completati oggi (dal KPI dashboard)
+        completati_oggi = kpi_dashboard.get('riepilogo', {}).get('completati_oggi', 0) if kpi_dashboard.get('success') else 0
+
+        # Operai online
+        operai_online = sum(1 for op in kpi_operai if op.get('saturazione', 0) > 0 or
+            (op.get('ultimo_accesso') and op['ultimo_accesso'] != 'Mai' and
+             dt.fromisoformat(op['ultimo_accesso']).date() == today))
 
         return jsonify({
             'success': True,
@@ -1068,7 +1073,10 @@ def get_admin_kpi():
                 'ordini_attivi': ordini_attivi,
                 'login_oggi': login_oggi,
                 'efficienza': efficienza,
-                'ritardi': ritardi
+                'ritardi': ritardi,
+                'completati_oggi': completati_oggi,
+                'operai_online': operai_online,
+                'totale_operai': len(kpi_operai)
             },
             'kpi_operai': kpi_operai
         }), 200

--- a/app/backend/database.py
+++ b/app/backend/database.py
@@ -1620,69 +1620,111 @@ class AuditManager:
     @staticmethod
     def get_kpi_operai() -> list[dict]:
         """
-        Calcola KPI per ogni operaio da processing_steps:
-        - ordini completati (count WHERE timestamp_fine IS NOT NULL)
-        - tempo medio per ordine
-        - ultimo accesso (da users.last_login)
+        Calcola KPI reali per ogni operaio:
+        - ordini completati (count distinct order_id)
+        - tempo medio per ordine (da PhaseSession o fallback ProcessingStep)
+        - puntualita: % ordini completati entro data_consegna
+        - ritardi: ordini attivi scaduti assegnati all'operatore
+        - saturazione: ore lavorate oggi / 8h turno
         """
         session = get_session()
         try:
             from sqlalchemy import func, and_
+            now = datetime.utcnow()
+            today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            TURNO_ORE = 8
 
-            # Query: JOIN processing_steps on operatore = user.name
-            # WHERE timestamp_fine IS NOT NULL GROUP BY operatore
-            query = session.query(
-                User.name,
-                User.id,
-                User.role,
-                User.initials,
-                User.last_login,
-                func.count(ProcessingStep.id).label('completed_phases_count')
-            ).outerjoin(
-                ProcessingStep,
-                and_(
-                    ProcessingStep.operatore == User.name,
-                    ProcessingStep.timestamp_fine.isnot(None)
-                )
-            ).filter(
-                User.is_active == True
-            ).group_by(
-                User.id
+            # Pre-carica dati per evitare N+1
+            all_orders = {o.id: o for o in session.query(Order).all()}
+            all_steps = session.query(ProcessingStep).all()
+            steps_by_order = {}
+            for s in all_steps:
+                steps_by_order.setdefault(s.order_id, []).append(s)
+            steps_by_operator = {}
+            for s in all_steps:
+                if s.operatore:
+                    steps_by_operator.setdefault(s.operatore, []).append(s)
+
+            # Sessioni chiuse per tempo reale
+            all_closed_sessions = session.query(PhaseSession).filter(
+                PhaseSession.timestamp_fine != None
             ).all()
+            sessions_by_step = {}
+            for ps in all_closed_sessions:
+                sessions_by_step.setdefault(ps.step_id, []).append(ps)
+            sessions_by_operator = {}
+            for ps in all_closed_sessions:
+                op_name = ps.operatore or 'unknown'
+                sessions_by_operator.setdefault(op_name, []).append(ps)
+
+            users = session.query(User).filter(User.is_active == True).all()
 
             kpi_list = []
-            for row in query:
-                name, user_id, role, initials, last_login, completed_count = row
+            for user in users:
+                name = user.name
+                op_steps = steps_by_operator.get(name, [])
+                completed_steps = [s for s in op_steps if s.timestamp_fine]
 
-                # Calcola tempo medio per operaio
-                avg_time = session.query(
-                    func.avg(ProcessingStep.timestamp_fine - ProcessingStep.timestamp_inizio)
-                ).filter(
-                    ProcessingStep.operatore == name,
-                    ProcessingStep.timestamp_fine.isnot(None)
-                ).scalar()
+                # Ordini unici completati
+                ordini_completati = len(set(s.order_id for s in completed_steps))
 
-                tempo_medio = OrderManager._format_duration(avg_time) if avg_time else "N/A"
+                # Tempo medio reale per step (da sessioni)
+                step_durations = []
+                for s in completed_steps:
+                    step_ss = sessions_by_step.get(s.id, [])
+                    op_ss = [x for x in step_ss if x.operatore == name]
+                    if op_ss:
+                        secs = sum((x.timestamp_fine - x.timestamp_inizio).total_seconds() for x in op_ss)
+                        step_durations.append(secs)
+                    elif s.timestamp_inizio and s.timestamp_fine:
+                        step_durations.append((s.timestamp_fine - s.timestamp_inizio).total_seconds())
+                if step_durations:
+                    avg_secs = sum(step_durations) / len(step_durations)
+                    tempo_medio = OrderManager._format_duration(timedelta(seconds=avg_secs))
+                else:
+                    tempo_medio = "N/A"
 
-                # Conteggio ordini unici completati (non fasi, ma ordini)
-                ordini_completati = session.query(
-                    func.count(func.distinct(ProcessingStep.order_id))
-                ).filter(
-                    ProcessingStep.operatore == name,
-                    ProcessingStep.timestamp_fine.isnot(None)
-                ).scalar() or 0
+                # Puntualita: % ordini COMPLETATI in tempo
+                op_order_ids = set(s.order_id for s in completed_steps)
+                tot_completati = 0
+                in_tempo = 0
+                for oid in op_order_ids:
+                    order = all_orders.get(oid)
+                    if not order or order.status != 'COMPLETATO':
+                        continue
+                    tot_completati += 1
+                    if not order.data_consegna:
+                        continue
+                    order_steps = steps_by_order.get(oid, [])
+                    finished = [st.timestamp_fine for st in order_steps if st.timestamp_fine]
+                    if finished and max(finished) <= order.data_consegna:
+                        in_tempo += 1
+                puntualita = round((in_tempo / tot_completati * 100) if tot_completati > 0 else 100)
+
+                # Ritardi: ordini attivi scaduti dove l'operatore ha step non completato
+                active_steps = [s for s in op_steps if s.timestamp_inizio and not s.timestamp_fine]
+                ritardi = 0
+                for s in active_steps:
+                    order = all_orders.get(s.order_id)
+                    if order and order.data_consegna and order.data_consegna < now and order.status not in ('COMPLETATO', 'SPEDITO'):
+                        ritardi += 1
+
+                # Saturazione oggi: ore lavorate / 8h turno
+                op_sessions_oggi = [x for x in sessions_by_operator.get(name, []) if x.timestamp_fine >= today_start]
+                tempo_oggi_sec = sum((x.timestamp_fine - x.timestamp_inizio).total_seconds() for x in op_sessions_oggi)
+                saturazione = min(100, round(tempo_oggi_sec / (TURNO_ORE * 3600) * 100)) if tempo_oggi_sec > 0 else 0
 
                 kpi_list.append({
                     'operaio': name,
-                    'user_id': user_id,
-                    'role': role,
-                    'initials': initials,
+                    'user_id': user.id,
+                    'role': user.role,
+                    'initials': user.initials,
                     'ordini_completati': ordini_completati,
                     'tempo_medio': tempo_medio,
-                    'ultimo_accesso': last_login.isoformat() if last_login else 'Mai',
-                    'efficienza': 85 + (ordini_completati % 15),  # Mock: 85-99%
-                    'ritardi': max(0, 5 - (ordini_completati // 10)),  # Mock
-                    'rating': min(5.0, 3.5 + (ordini_completati / 20))  # Mock: 3.5-5.0
+                    'ultimo_accesso': user.last_login.isoformat() if user.last_login else 'Mai',
+                    'puntualita': puntualita,
+                    'ritardi': ritardi,
+                    'saturazione': saturazione
                 })
 
             return kpi_list
@@ -2563,24 +2605,59 @@ class KPIManager:
         try:
             now = datetime.utcnow()
             today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+            TURNO_ORE = 8  # Durata turno standard in ore
+
+            # === PRE-CARICAMENTO DATI (eliminare N+1) ===
+            all_orders = session.query(Order).all()
+            all_steps = session.query(ProcessingStep).all()
+
+            # Mappa order_id -> lista steps
+            steps_by_order = {}
+            for s in all_steps:
+                steps_by_order.setdefault(s.order_id, []).append(s)
+
+            # Pre-carica tutte le sessioni chiuse
+            all_closed_sessions = session.query(PhaseSession).filter(
+                PhaseSession.timestamp_fine != None
+            ).all()
+            sessions_by_step = {}
+            for ps in all_closed_sessions:
+                sessions_by_step.setdefault(ps.step_id, []).append(ps)
+            sessions_by_operator = {}
+            for ps in all_closed_sessions:
+                op_name = ps.operatore or 'unknown'
+                sessions_by_operator.setdefault(op_name, []).append(ps)
 
             # === RIEPILOGO ===
-            all_orders = session.query(Order).all()
             ordini_attivi = sum(1 for o in all_orders if o.status not in ('COMPLETATO', 'SPEDITO'))
-            completati_oggi = sum(1 for o in all_orders if o.status == 'COMPLETATO' and
-                session.query(ProcessingStep).filter(
-                    ProcessingStep.order_id == o.id,
-                    ProcessingStep.timestamp_fine != None,
-                    ProcessingStep.timestamp_fine >= today_start
-                ).first() is not None)
+
+            # Completati oggi: ordine COMPLETATO con ultimo step finito oggi
+            completati_oggi = 0
+            for o in all_orders:
+                if o.status != 'COMPLETATO':
+                    continue
+                order_steps = steps_by_order.get(o.id, [])
+                finished = [s.timestamp_fine for s in order_steps if s.timestamp_fine]
+                if finished and max(finished) >= today_start:
+                    completati_oggi += 1
+
             in_ritardo = sum(1 for o in all_orders
                 if o.data_consegna and o.data_consegna < now
                 and o.status not in ('COMPLETATO', 'SPEDITO'))
-            completati_totali = sum(1 for o in all_orders if o.status == 'COMPLETATO')
-            completati_in_tempo = sum(1 for o in all_orders
-                if o.status == 'COMPLETATO' and o.data_consegna
-                and any(s.timestamp_fine and s.timestamp_fine <= o.data_consegna
-                    for s in session.query(ProcessingStep).filter(ProcessingStep.order_id == o.id).all()))
+
+            # Efficienza puntualita: ordini dove ULTIMO step completato <= data_consegna
+            completati_totali = 0
+            completati_in_tempo = 0
+            for o in all_orders:
+                if o.status != 'COMPLETATO':
+                    continue
+                completati_totali += 1
+                if not o.data_consegna:
+                    continue
+                order_steps = steps_by_order.get(o.id, [])
+                finished = [s.timestamp_fine for s in order_steps if s.timestamp_fine]
+                if finished and max(finished) <= o.data_consegna:
+                    completati_in_tempo += 1
             efficienza = round((completati_in_tempo / completati_totali * 100) if completati_totali > 0 else 100)
 
             riepilogo = {
@@ -2591,50 +2668,35 @@ class KPIManager:
             }
 
             # === KPI OPERATORI ===
-            # Pre-carica tutte le sessioni chiuse per calcolo tempo reale
-            all_closed_sessions = session.query(PhaseSession).filter(
-                PhaseSession.timestamp_fine != None
-            ).all()
-            # Mappa step_id -> lista sessioni chiuse
-            sessions_by_step = {}
-            for ps in all_closed_sessions:
-                sessions_by_step.setdefault(ps.step_id, []).append(ps)
-            # Mappa operatore_nome -> lista sessioni chiuse
-            sessions_by_operator = {}
-            for ps in all_closed_sessions:
-                op_name = ps.operatore or 'unknown'
-                sessions_by_operator.setdefault(op_name, []).append(ps)
-
             operatori_kpi = []
             operators = session.query(User).filter(
                 User.role.in_(['Operaio Officina', 'Operaio Laser', 'Capo Officina']),
                 User.is_active == True
             ).all()
 
+            # Pre-carica steps completati per operatore (evita query nel loop)
+            all_completed_steps_by_op = {}
+            for s in all_steps:
+                if s.operatore and s.timestamp_fine:
+                    all_completed_steps_by_op.setdefault(s.operatore, []).append(s)
+
+            # Mappa order_id -> Order per lookup puntualita
+            orders_by_id = {o.id: o for o in all_orders}
+
             for op in operators:
-                # Sessioni chiuse di questo operatore (tempo reale lavorato)
                 op_sessions = sessions_by_operator.get(op.name, [])
-
-                # Steps completati da questo operatore
-                completed_steps = session.query(ProcessingStep).filter(
-                    ProcessingStep.operatore == op.name,
-                    ProcessingStep.timestamp_fine != None
-                ).all()
-
-                # Steps completati oggi
+                completed_steps = all_completed_steps_by_op.get(op.name, [])
                 steps_oggi = [s for s in completed_steps if s.timestamp_fine >= today_start]
 
                 # Tempo medio per step: somma sessioni reali / numero step
                 step_real_times = []
                 for s in completed_steps:
                     step_ss = sessions_by_step.get(s.id, [])
-                    # Filtra solo sessioni di questo operatore
                     op_step_ss = [x for x in step_ss if x.operatore == op.name]
                     if op_step_ss:
                         real_secs = sum((x.timestamp_fine - x.timestamp_inizio).total_seconds() for x in op_step_ss)
                         step_real_times.append(real_secs)
                     elif s.timestamp_inizio and s.timestamp_fine:
-                        # Fallback: nessuna sessione trovata, usa durata step
                         step_real_times.append((s.timestamp_fine - s.timestamp_inizio).total_seconds())
                 tempo_medio_min = round(sum(step_real_times) / len(step_real_times) / 60) if step_real_times else None
 
@@ -2642,10 +2704,9 @@ class KPIManager:
                 sessioni_oggi = [x for x in op_sessions if x.timestamp_fine >= today_start]
                 tempo_oggi_sec = sum((x.timestamp_fine - x.timestamp_inizio).total_seconds() for x in sessioni_oggi)
 
-                # Ordini unici completati
                 ordini_unici = len(set(s.order_id for s in completed_steps))
 
-                # Step attivo (in corso) — cerca sessione attiva, non solo step
+                # Step attivo (in corso)
                 active_session = session.query(PhaseSession).filter(
                     PhaseSession.operatore == op.name,
                     PhaseSession.timestamp_fine == None
@@ -2656,23 +2717,33 @@ class KPIManager:
                         ProcessingStep.id == active_session.step_id
                     ).first()
 
-                # Clienti assegnati
                 clienti = session.query(OperatorClient).filter(
                     OperatorClient.operator_id == op.id
                 ).count()
 
-                # Online = last_login oggi
                 is_online = op.last_login and op.last_login >= today_start
 
-                # Efficienza: ore lavorate effettive / ore di turno (8h) * 100
-                # Se ha lavorato oggi, calcola quanto del turno ha usato
-                total_real_secs = sum(step_real_times) if step_real_times else 0
-                if total_real_secs > 0 and ordini_unici > 0:
-                    # Media ordini/ora: ordini completati / ore lavorate totali
-                    ore_lavorate = total_real_secs / 3600
-                    eff = min(100, round((ordini_unici / max(ore_lavorate, 0.5)) * 10))
-                else:
-                    eff = 0
+                # SATURAZIONE: ore lavorate oggi / turno 8h * 100
+                saturazione = min(100, round(tempo_oggi_sec / (TURNO_ORE * 3600) * 100)) if tempo_oggi_sec > 0 else 0
+
+                # PUNTUALITA: % ordini completati in tempo dall'operatore
+                # Per ogni ordine unico dell'operatore che e' COMPLETATO,
+                # verifica se l'ultimo step globale e' entro data_consegna
+                ordini_completati_op = set(s.order_id for s in completed_steps)
+                op_totale_completati = 0
+                op_in_tempo = 0
+                for oid in ordini_completati_op:
+                    order = orders_by_id.get(oid)
+                    if not order or order.status != 'COMPLETATO':
+                        continue
+                    op_totale_completati += 1
+                    if not order.data_consegna:
+                        continue
+                    order_steps = steps_by_order.get(oid, [])
+                    finished = [st.timestamp_fine for st in order_steps if st.timestamp_fine]
+                    if finished and max(finished) <= order.data_consegna:
+                        op_in_tempo += 1
+                puntualita = round((op_in_tempo / op_totale_completati * 100) if op_totale_completati > 0 else 100)
 
                 operatori_kpi.append({
                     'id': op.id,
@@ -2688,13 +2759,13 @@ class KPIManager:
                     'clienti_assegnati': clienti,
                     'fase_attiva': active_step.fase if active_step else None,
                     'ordine_attivo': active_step.order_id if active_step else None,
-                    'efficienza': eff
+                    'saturazione': saturazione,
+                    'puntualita': puntualita
                 })
 
             # === KPI FASI/MACCHINARI ===
             fasi_kpi = []
             for fase_nome in ['LASER', 'PIEGA', 'SALDATURA', 'PULIZIA']:
-                # In coda: ordini con fase_corrente = questa fase, senza step attivo
                 in_coda_orders = session.query(Order).filter(
                     Order.fase_corrente == fase_nome,
                     Order.status.notin_(['COMPLETATO', 'SPEDITO'])
@@ -2706,14 +2777,9 @@ class KPIManager:
                 ).count()
                 in_coda = max(0, len(in_coda_orders) - active_in_fase)
 
-                # Completati
-                completed_in_fase = session.query(ProcessingStep).filter(
-                    ProcessingStep.fase == fase_nome,
-                    ProcessingStep.timestamp_fine != None
-                ).all()
+                completed_in_fase = [s for s in all_steps if s.fase == fase_nome and s.timestamp_fine]
                 completati_oggi_fase = sum(1 for s in completed_in_fase if s.timestamp_fine >= today_start)
 
-                # Tempo medio reale: somma sessioni per step / numero step
                 durations_fase = []
                 for s in completed_in_fase:
                     step_ss = sessions_by_step.get(s.id, [])

--- a/app/frontend/admin.html
+++ b/app/frontend/admin.html
@@ -595,60 +595,40 @@ body {
       <div class="kpi-grid">
         <div class="kpi-card">
           <div class="kpi-label">Operai Online</div>
-          <div class="kpi-value">4</div>
-          <div class="kpi-unit">di 6 disponibili</div>
-          <div class="kpi-trend">↑ Tutti operativi</div>
+          <div class="kpi-value" id="kpi-operai-online">—</div>
+          <div class="kpi-unit" id="kpi-operai-totale">caricamento...</div>
         </div>
 
         <div class="kpi-card">
           <div class="kpi-label">Ordini Attivi</div>
-          <div class="kpi-value">18</div>
+          <div class="kpi-value" id="kpi-ordini-attivi">—</div>
           <div class="kpi-unit">in lavorazione</div>
-          <div class="kpi-trend">↑ +3 da ieri</div>
         </div>
 
         <div class="kpi-card">
-          <div class="kpi-label">Efficienza Sistema</div>
-          <div class="kpi-value">83%</div>
-          <div class="kpi-unit">media globale</div>
-          <div class="kpi-trend">↑ +2% questa settimana</div>
+          <div class="kpi-label">Puntualit&agrave; Consegne</div>
+          <div class="kpi-value" id="kpi-efficienza">—</div>
+          <div class="kpi-unit">ordini consegnati in tempo</div>
         </div>
 
         <div class="kpi-card">
-          <div class="kpi-label">Ritardi Critici</div>
-          <div class="kpi-value">4</div>
-          <div class="kpi-unit">ordini</div>
-          <div class="kpi-trend">↓ -1 da ieri</div>
+          <div class="kpi-label">Ordini in Ritardo</div>
+          <div class="kpi-value" id="kpi-ritardi">—</div>
+          <div class="kpi-unit">scaduti non completati</div>
         </div>
       </div>
 
       <div class="kpi-grid">
         <div class="kpi-card">
-          <div class="kpi-label">Macchine Attive</div>
-          <div class="kpi-value">5</div>
-          <div class="kpi-unit">di 6</div>
-          <div class="kpi-trend">CNC 02 in manutenzione</div>
-        </div>
-
-        <div class="kpi-card">
           <div class="kpi-label">Login Oggi</div>
-          <div class="kpi-value">12</div>
+          <div class="kpi-value" id="kpi-login-oggi">—</div>
           <div class="kpi-unit">accessi registrati</div>
-          <div class="kpi-trend">Ultimi 24 ore</div>
-        </div>
-
-        <div class="kpi-card">
-          <div class="kpi-label">Tempo Medio</div>
-          <div class="kpi-value">3h</div>
-          <div class="kpi-unit">24min per ordine</div>
-          <div class="kpi-trend">→ Stabile</div>
         </div>
 
         <div class="kpi-card">
           <div class="kpi-label">Completati Oggi</div>
-          <div class="kpi-value">8</div>
+          <div class="kpi-value" id="kpi-completati-oggi">—</div>
           <div class="kpi-unit">ordini</div>
-          <div class="kpi-trend">↑ +2 del solito</div>
         </div>
       </div>
     </div>
@@ -664,162 +644,14 @@ body {
             <th>Operaio</th>
             <th>Ordini Completati</th>
             <th>Tempo Medio</th>
-            <th>Efficienza</th>
+            <th>Puntualit&agrave;</th>
+            <th>Saturazione Oggi</th>
             <th>Ritardi</th>
-            <th>Rating</th>
-            <th>Ultimoaccesso</th>
+            <th>Ultimo Accesso</th>
           </tr>
         </thead>
-        <tbody>
-          <tr>
-            <td>
-              <div class="operator-name">Mirko Sandionigi</div>
-              <div class="operator-role">Reparto Laser</div>
-            </td>
-            <td>
-              <div class="metric-value">42</div>
-              <div class="metric-label">questa settimana</div>
-            </td>
-            <td>
-              <div class="metric-value">2h 45m</div>
-              <div class="metric-label">per ordine</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">88%</div>
-              <div class="metric-label">eccellente</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">0</div>
-              <div class="metric-label">nessun ritardo</div>
-            </td>
-            <td>
-              <div class="metric-value">⭐⭐⭐⭐⭐</div>
-              <div class="metric-label">5.0/5.0</div>
-            </td>
-            <td>
-              <div class="metric-label">Oggi 09:30</div>
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              <div class="operator-name">Enzo Masciari</div>
-              <div class="operator-role">Officina</div>
-            </td>
-            <td>
-              <div class="metric-value">38</div>
-              <div class="metric-label">questa settimana</div>
-            </td>
-            <td>
-              <div class="metric-value">3h 12m</div>
-              <div class="metric-label">per ordine</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #ffa502;">81%</div>
-              <div class="metric-label">buono</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #ffa502;">1</div>
-              <div class="metric-label">1 ritardo minore</div>
-            </td>
-            <td>
-              <div class="metric-value">⭐⭐⭐⭐</div>
-              <div class="metric-label">4.5/5.0</div>
-            </td>
-            <td>
-              <div class="metric-label">Oggi 11:15</div>
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              <div class="operator-name">Elena Colombo</div>
-              <div class="operator-role">Impiegata</div>
-            </td>
-            <td>
-              <div class="metric-value">45</div>
-              <div class="metric-label">questa settimana</div>
-            </td>
-            <td>
-              <div class="metric-value">2h 30m</div>
-              <div class="metric-label">per ordine</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">91%</div>
-              <div class="metric-label">eccellente</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">0</div>
-              <div class="metric-label">nessun ritardo</div>
-            </td>
-            <td>
-              <div class="metric-value">⭐⭐⭐⭐⭐</div>
-              <div class="metric-label">5.0/5.0</div>
-            </td>
-            <td>
-              <div class="metric-label">Oggi 08:45</div>
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              <div class="operator-name">Paolo Scola</div>
-              <div class="operator-role">Responsabile</div>
-            </td>
-            <td>
-              <div class="metric-value">12</div>
-              <div class="metric-label">ordini supervisione</div>
-            </td>
-            <td>
-              <div class="metric-value">45m</div>
-              <div class="metric-label">per supervisione</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">95%</div>
-              <div class="metric-label">perfetto</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #22c55e;">0</div>
-              <div class="metric-label">nessun ritardo</div>
-            </td>
-            <td>
-              <div class="metric-value">⭐⭐⭐⭐⭐</div>
-              <div class="metric-label">5.0/5.0</div>
-            </td>
-            <td>
-              <div class="metric-label">Oggi 07:30</div>
-            </td>
-          </tr>
-
-          <tr>
-            <td>
-              <div class="operator-name">Stefano Villa</div>
-              <div class="operator-role">Capo Officina</div>
-            </td>
-            <td>
-              <div class="metric-value">36</div>
-              <div class="metric-label">questa settimana</div>
-            </td>
-            <td>
-              <div class="metric-value">3h 25m</div>
-              <div class="metric-label">per ordine</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #ffa502;">75%</div>
-              <div class="metric-label">discreto</div>
-            </td>
-            <td>
-              <div class="metric-value" style="color: #ef4444;">2</div>
-              <div class="metric-label">2 ritardi</div>
-            </td>
-            <td>
-              <div class="metric-value">⭐⭐⭐</div>
-              <div class="metric-label">3.5/5.0</div>
-            </td>
-            <td>
-              <div class="metric-label">Ieri 17:30</div>
-            </td>
-          </tr>
+        <tbody id="kpi-operai-tbody">
+          <tr><td colspan="7" style="text-align:center; padding:32px; color: var(--text-secondary);">Caricamento KPI...</td></tr>
         </tbody>
       </table>
     </div>
@@ -1399,13 +1231,68 @@ async function loadKPI() {
   try {
     const resp = await fetch(`${API_BASE}/api/admin/kpi`);
     if (!resp.ok) throw new Error('Failed to load KPI');
-    const data = resp.json();
+    const data = await resp.json();
+    if (!data.success) return;
 
-    // Populate KPI cards (basic implementation)
-    // KPI data loaded
+    const g = data.kpi_globali;
+
+    // Overview cards
+    const setVal = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
+    setVal('kpi-operai-online', g.operai_online || 0);
+    setVal('kpi-operai-totale', 'di ' + (g.totale_operai || 0) + ' registrati');
+    setVal('kpi-ordini-attivi', g.ordini_attivi || 0);
+    setVal('kpi-efficienza', (g.efficienza || 0) + '%');
+    setVal('kpi-ritardi', g.ritardi || 0);
+    setVal('kpi-login-oggi', g.login_oggi || 0);
+    setVal('kpi-completati-oggi', g.completati_oggi || 0);
+
+    // KPI Operai table
+    const tbody = document.getElementById('kpi-operai-tbody');
+    if (tbody && data.kpi_operai && data.kpi_operai.length > 0) {
+      tbody.innerHTML = data.kpi_operai.map(op => {
+        const puntColor = op.puntualita >= 80 ? '#22c55e' : op.puntualita >= 50 ? '#ffa502' : '#ef4444';
+        const puntLabel = op.puntualita >= 80 ? 'eccellente' : op.puntualita >= 50 ? 'buono' : 'da migliorare';
+        const satColor = op.saturazione >= 60 ? '#22c55e' : op.saturazione >= 30 ? '#ffa502' : '#94a3b8';
+        const ritColor = op.ritardi === 0 ? '#22c55e' : op.ritardi <= 2 ? '#ffa502' : '#ef4444';
+        const ritLabel = op.ritardi === 0 ? 'nessun ritardo' : op.ritardi + ' ordini scaduti';
+        const accesso = op.ultimo_accesso === 'Mai' ? 'Mai' : formatAccesso(op.ultimo_accesso);
+
+        return '<tr>' +
+          '<td><div class="operator-name">' + escapeHtml(op.operaio) + '</div><div class="operator-role">' + escapeHtml(op.role || '') + '</div></td>' +
+          '<td><div class="metric-value">' + op.ordini_completati + '</div><div class="metric-label">totali</div></td>' +
+          '<td><div class="metric-value">' + escapeHtml(op.tempo_medio) + '</div><div class="metric-label">per fase</div></td>' +
+          '<td><div class="metric-value" style="color:' + puntColor + ';">' + op.puntualita + '%</div><div class="metric-label">' + puntLabel + '</div></td>' +
+          '<td><div class="metric-value" style="color:' + satColor + ';">' + op.saturazione + '%</div>' +
+            '<div style="background:#e5e7eb;border-radius:4px;height:6px;margin-top:4px;"><div style="background:' + satColor + ';height:100%;border-radius:4px;width:' + op.saturazione + '%;"></div></div></td>' +
+          '<td><div class="metric-value" style="color:' + ritColor + ';">' + op.ritardi + '</div><div class="metric-label">' + ritLabel + '</div></td>' +
+          '<td><div class="metric-label">' + escapeHtml(accesso) + '</div></td>' +
+        '</tr>';
+      }).join('');
+    } else if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:32px;color:var(--text-secondary);">Nessun operaio trovato</td></tr>';
+    }
   } catch (e) {
     console.error('Error loading KPI:', e);
   }
+}
+
+function formatAccesso(isoStr) {
+  try {
+    const d = new Date(isoStr);
+    const oggi = new Date();
+    const isToday = d.toDateString() === oggi.toDateString();
+    const ieri = new Date(oggi); ieri.setDate(ieri.getDate() - 1);
+    const isYesterday = d.toDateString() === ieri.toDateString();
+    const time = d.toLocaleTimeString('it-IT', { hour: '2-digit', minute: '2-digit' });
+    if (isToday) return 'Oggi ' + time;
+    if (isYesterday) return 'Ieri ' + time;
+    return d.toLocaleDateString('it-IT', { day: '2-digit', month: '2-digit' }) + ' ' + time;
+  } catch(e) { return isoStr; }
+}
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
 }
 
 // ── LOAD AUDIT LOG ──
@@ -1432,7 +1319,7 @@ function switchScreen(screenId) {
   }
 
   // Load data based on screen
-  if (screenId === 'overview') {
+  if (screenId === 'overview' || screenId === 'kpi-operai') {
     loadKPI();
   } else if (screenId === 'audit') {
     loadAuditLog();

--- a/app/frontend/approva-ordine.html
+++ b/app/frontend/approva-ordine.html
@@ -3070,7 +3070,8 @@ function renderKPIOperators(ops) {
   container.innerHTML = ops.map(op => {
     const onlineColor = op.is_online ? '#22c55e' : '#d1d5db';
     const onlineText = op.is_online ? 'Online' : 'Offline';
-    const effColor = op.efficienza >= 80 ? '#22c55e' : op.efficienza >= 50 ? '#f59e0b' : '#ef4444';
+    const satColor = op.saturazione >= 60 ? '#22c55e' : op.saturazione >= 30 ? '#f59e0b' : '#94a3b8';
+    const puntColor = op.puntualita >= 80 ? '#22c55e' : op.puntualita >= 50 ? '#f59e0b' : '#ef4444';
     const faseAttiva = op.fase_attiva
       ? `<span style="background: ${(faseConfig[op.fase_attiva] || {}).color || '#666'}; color: white; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 700;">${op.fase_attiva}</span>`
       : '<span style="color: var(--text-secondary); font-size: 11px;">Libero</span>';
@@ -3108,13 +3109,22 @@ function renderKPIOperators(ops) {
           <div class="kpi-op-stat-label">Lavorato oggi</div>
         </div>
       </div>
-      <div>
+      <div style="margin-bottom: 6px;">
         <div style="display: flex; justify-content: space-between; font-size: 11px; margin-bottom: 4px;">
-          <span style="color: var(--text-secondary);">Efficienza</span>
-          <span style="font-weight: 700; color: ${effColor};">${op.efficienza}%</span>
+          <span style="color: var(--text-secondary);">Saturazione turno</span>
+          <span style="font-weight: 700; color: ${satColor};">${op.saturazione}%</span>
         </div>
         <div class="kpi-op-bar-bg">
-          <div class="kpi-op-bar-fill" style="width: ${op.efficienza}%; background: ${effColor};"></div>
+          <div class="kpi-op-bar-fill" style="width: ${op.saturazione}%; background: ${satColor};"></div>
+        </div>
+      </div>
+      <div>
+        <div style="display: flex; justify-content: space-between; font-size: 11px; margin-bottom: 4px;">
+          <span style="color: var(--text-secondary);">Puntualit&agrave;</span>
+          <span style="font-weight: 700; color: ${puntColor};">${op.puntualita}%</span>
+        </div>
+        <div class="kpi-op-bar-bg">
+          <div class="kpi-op-bar-fill" style="width: ${op.puntualita}%; background: ${puntColor};"></div>
         </div>
       </div>
     </div>`;


### PR DESCRIPTION
## Summary

I KPI erano completamente inaffidabili. Questa PR risolve 6 problemi critici:

- **Efficienza puntualità errata**: usava `any()` — bastava UNA fase in tempo per considerare l'ordine "on-time". Ora verifica che l'ULTIMO step sia completato entro `data_consegna`
- **Valori mock nel backend admin**: efficienza (`85 + ordini % 15`), ritardi e rating erano formule inventate. Ora calcolati da dati reali
- **Efficienza globale admin errata**: confrontava `data_consegna` con la data odierna invece che con la data di completamento effettivo
- **Formula efficienza operatore senza significato**: `(ordini/ore)*10` sostituita con due metriche reali: **saturazione turno** (ore lavorate/8h) e **puntualità consegne** (% ordini in tempo)
- **N+1 query**: eliminato il pattern di query nel loop (pre-caricamento batch)
- **Admin dashboard statico**: overview e tabella operai erano hardcoded nell'HTML con nomi e numeri finti. Ora dinamici dal backend

### File modificati

| File | Modifica |
|------|----------|
| `app/backend/database.py` | `KPIManager.get_dashboard_kpi()` + `AuditManager.get_kpi_operai()` riscritti |
| `app/backend/app.py` | `/api/admin/kpi` con efficienza corretta |
| `app/frontend/admin.html` | Overview + tabella operai dinamici, rimossa colonna Rating |
| `app/frontend/approva-ordine.html` | Doppia barra saturazione + puntualità per operatore |

## Test plan

- [ ] `python -m py_compile app/backend/database.py && python -m py_compile app/backend/app.py`
- [ ] Avviare server e verificare `GET /api/kpi/dashboard` restituisce `saturazione` e `puntualita` per operatore
- [ ] Verificare `GET /api/admin/kpi` — efficienza e ritardi sono valori reali (non 85-99%)
- [ ] Aprire admin.html — overview cards e tabella operai si popolano dinamicamente
- [ ] Aprire approva-ordine.html tab KPI — operatori mostrano due barre (saturazione + puntualità)

https://claude.ai/code/session_011W4bNzexHpuF7tT1URnhWV