### PR TITLE
feat: workflow chiusura amministrativa ordini (DDT/fattura)

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 # Importa moduli locali
 from .models import initialize_database, Order, OrderFile, get_session, SupportRequest as SRModel
-from .database import OrderManager, UserManager, AuditManager, ArchiveManager, NotificationManager, OperatorClientManager, AlertManager, KPIManager, DelegationManager, SupportManager
+from .database import OrderManager, UserManager, AuditManager, ArchiveManager, FatturazioneManager, NotificationManager, OperatorClientManager, AlertManager, KPIManager, DelegationManager, SupportManager
 
 app = Flask(__name__, static_folder=None)
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024  # 50 MB max upload
@@ -1097,6 +1097,111 @@ def get_admin_audit_log():
 
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 400
+
+# ============ API FATTURAZIONE (Chiusura Amministrativa) ============
+
+@app.route('/api/ordini-da-fatturare', methods=['GET'])
+def get_ordini_da_fatturare():
+    """Recupera ordini in attesa di chiusura amministrativa"""
+    try:
+        page = max(1, request.args.get('page', 1, type=int))
+        limit = min(request.args.get('limit', 20, type=int), 100)
+        sort_by = request.args.get('sort_by', 'data_consegna')
+        sort_dir = request.args.get('sort_dir', 'asc')
+
+        filters = {}
+        if request.args.get('cliente'):
+            filters['cliente'] = request.args.get('cliente')
+        if request.args.get('numero_ordine'):
+            filters['numero_ordine'] = request.args.get('numero_ordine')
+        if request.args.get('date_from'):
+            filters['date_from'] = request.args.get('date_from')
+        if request.args.get('date_to'):
+            filters['date_to'] = request.args.get('date_to')
+
+        result = FatturazioneManager.get_ordini_da_fatturare(
+            filters=filters if filters else None,
+            page=page, limit=limit,
+            sort_by=sort_by, sort_dir=sort_dir
+        )
+
+        return jsonify({'success': True, 'data': result}), 200
+
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+
+@app.route('/api/ordini-da-fatturare/count', methods=['GET'])
+def get_ordini_da_fatturare_count():
+    """Conteggio ordini da fatturare (per badge)"""
+    try:
+        count = FatturazioneManager.get_count()
+        return jsonify({'success': True, 'count': count}), 200
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+
+@app.route('/api/orders/<order_id>/salva-bozza-fattura', methods=['PUT'])
+def salva_bozza_fattura(order_id):
+    """Salva dati DDT/fattura come bozza senza chiudere l'ordine"""
+    try:
+        data = request.get_json() or {}
+        result = FatturazioneManager.salva_bozza(order_id, data)
+        if not result['success']:
+            return jsonify(result), 400
+        return jsonify(result), 200
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+
+@app.route('/api/orders/<order_id>/chiudi-amministrativo', methods=['POST'])
+def chiudi_ordine_amministrativo(order_id):
+    """Chiude ordine amministrativamente — status → CHIUSO"""
+    try:
+        data = request.get_json() or {}
+        user_id = data.get('user_id', '')
+        result = FatturazioneManager.chiudi_ordine(order_id, data, user_id)
+        if not result['success']:
+            return jsonify(result), 400
+
+        # Log audit
+        AuditManager.log(
+            user_id=user_id,
+            action='CHIUSURA_AMMINISTRATIVA',
+            entity_type='order',
+            entity_id=order_id,
+            detail=f"DDT: {data.get('numero_ddt', '-')}, Fattura: {data.get('numero_fattura', '-')}",
+            ip_address=request.remote_addr
+        )
+
+        return jsonify(result), 200
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
+
+@app.route('/api/orders/<order_id>/riapri', methods=['POST'])
+def riapri_ordine(order_id):
+    """Riapre ordine CHIUSO riportandolo a DA_FATTURARE"""
+    try:
+        data = request.get_json() or {}
+        user_id = data.get('user_id', '')
+        result = FatturazioneManager.riapri_ordine(order_id)
+        if not result['success']:
+            return jsonify(result), 400
+
+        AuditManager.log(
+            user_id=user_id,
+            action='RIAPERTURA_ORDINE',
+            entity_type='order',
+            entity_id=order_id,
+            detail='Ordine riaperto da CHIUSO a DA_FATTURARE',
+            ip_address=request.remote_addr
+        )
+
+        return jsonify(result), 200
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 400
+
 
 # ============ API ARCHIVE ============
 

--- a/app/backend/database.py
+++ b/app/backend/database.py
@@ -644,7 +644,7 @@ class OrderManager:
 
             if fase_successiva == "COMPLETATO":
                 order.fase_corrente = "COMPLETATO"
-                order.status = "COMPLETATO"
+                order.status = "DA_FATTURARE"
                 total_time = OrderManager._calculate_order_total_time(order_id, session)
                 notification = OrderNotification(
                     id=str(uuid.uuid4()),
@@ -969,8 +969,8 @@ class OrderManager:
             )
             session.add(notification)
 
-            # Marca ordine come completato definitivamente (status speciale)
-            order.status = "COMPLETATO"
+            # Marca ordine come da fatturare (chiusura amministrativa necessaria)
+            order.status = "DA_FATTURARE"
             session.commit()
 
             return {"success": True, "tempi_totali": total_time}
@@ -994,7 +994,7 @@ class OrderManager:
             if not order:
                 return {"success": False, "error": "Ordine non trovato"}
 
-            if order.status == "COMPLETATO":
+            if order.status in ("COMPLETATO", "DA_FATTURARE", "CHIUSO"):
                 return {"success": False, "error": "Ordine già completato"}
 
             now = datetime.utcnow()
@@ -1023,9 +1023,9 @@ class OrderManager:
                 if note:
                     step.note = note
 
-            # Marca ordine come completato
+            # Marca ordine come da fatturare (chiusura amministrativa necessaria)
             order.fase_corrente = "COMPLETATO"
-            order.status = "COMPLETATO"
+            order.status = "DA_FATTURARE"
 
             # Crea OrderNotification con tempo totale
             total_time = OrderManager._calculate_order_total_time(order_id, session)
@@ -1175,7 +1175,7 @@ class OrderManager:
 
             order.fase_corrente = new_phase
             if new_phase == "COMPLETATO":
-                order.status = "COMPLETATO"
+                order.status = "DA_FATTURARE"
             elif new_phase == "PARZIALE":
                 order.status = "PARZIALE"
             else:
@@ -1748,7 +1748,7 @@ class ArchiveManager:
             from sqlalchemy import func
 
             query = session.query(Order).filter(
-                Order.status.in_(["COMPLETATO", "PARZIALE"]),
+                Order.status.in_(["CHIUSO", "PARZIALE"]),
                 Order.parent_order_id.is_(None)  # Escludi lotti figli
             )
 
@@ -1834,7 +1834,14 @@ class ArchiveManager:
                     'status': order.status,
                     'lotto_numero': order.lotto_numero or 0,
                     'lotto_nome': order.lotto_nome or '',
-                    'lotti_detail': lotti_detail
+                    'lotti_detail': lotti_detail,
+                    # Dati chiusura amministrativa
+                    'numero_ddt': order.numero_ddt or '',
+                    'data_ddt': order.data_ddt.isoformat() if order.data_ddt else '',
+                    'numero_fattura': order.numero_fattura or '',
+                    'data_fattura': order.data_fattura.isoformat() if order.data_fattura else '',
+                    'note_chiusura': order.note_chiusura or '',
+                    'data_chiusura_amministrativa': order.data_chiusura_amministrativa.isoformat() if order.data_chiusura_amministrativa else '',
                 })
 
             total_pages = (total + limit - 1) // limit
@@ -1926,6 +1933,13 @@ class ArchiveManager:
                     for step in steps
                 ],
                 'status': order.status,
+                # Dati chiusura amministrativa
+                'numero_ddt': order.numero_ddt or '',
+                'data_ddt': order.data_ddt.isoformat() if order.data_ddt else '',
+                'numero_fattura': order.numero_fattura or '',
+                'data_fattura': order.data_fattura.isoformat() if order.data_fattura else '',
+                'note_chiusura': order.note_chiusura or '',
+                'data_chiusura_amministrativa': order.data_chiusura_amministrativa.isoformat() if order.data_chiusura_amministrativa else '',
                 'support_requests': [{
                     'id': sr.id,
                     'operatore_principale': sr.operatore_principale,
@@ -1947,7 +1961,7 @@ class ArchiveManager:
         session = get_session()
         try:
             query = session.query(Order).filter(
-                Order.status.in_(["COMPLETATO", "PARZIALE"])
+                Order.status.in_(["CHIUSO", "PARZIALE"])
             )
             query = ArchiveManager._apply_archive_filters(query, filters, session)
             orders = query.order_by(Order.data_consegna.desc()).all()
@@ -2003,7 +2017,7 @@ class ArchiveManager:
         session = get_session()
         try:
             query = session.query(Order).filter(
-                Order.status.in_(["COMPLETATO", "PARZIALE"]),
+                Order.status.in_(["CHIUSO", "PARZIALE"]),
                 Order.parent_order_id.is_(None)  # Solo ordini padre/normali
             )
             query = ArchiveManager._apply_archive_filters(query, filters, session)
@@ -2173,7 +2187,7 @@ class ArchiveManager:
             operators = session.query(ProcessingStep.operatore).join(
                 Order, Order.id == ProcessingStep.order_id
             ).filter(
-                Order.status.in_(["COMPLETATO", "PARZIALE"]),
+                Order.status.in_(["CHIUSO", "PARZIALE"]),
                 ProcessingStep.operatore.isnot(None)
             ).distinct().all()
             return sorted([op[0] for op in operators if op[0]])
@@ -2186,9 +2200,231 @@ class ArchiveManager:
         session = get_session()
         try:
             clients = session.query(Order.cliente).filter(
-                Order.status.in_(["COMPLETATO", "PARZIALE"])
+                Order.status.in_(["CHIUSO", "PARZIALE"])
             ).distinct().all()
             return sorted([c[0] for c in clients if c[0]])
+        finally:
+            session.close()
+
+
+class FatturazioneManager:
+    """Gestore ordini da fatturare — chiusura amministrativa (DDT/Fattura)"""
+
+    @staticmethod
+    def get_ordini_da_fatturare(filters: dict = None, page: int = 1, limit: int = 20,
+                                 sort_by: str = 'data_consegna', sort_dir: str = 'asc') -> dict:
+        """Recupera ordini in stato DA_FATTURARE con paginazione e filtri"""
+        session = get_session()
+        try:
+            query = session.query(Order).filter(
+                Order.status == "DA_FATTURARE",
+                Order.is_deleted == False,
+                Order.parent_order_id.is_(None)
+            )
+
+            # Filtri
+            if filters:
+                if filters.get('cliente'):
+                    query = query.filter(Order.cliente.ilike(f"%{filters['cliente']}%"))
+                if filters.get('numero_ordine'):
+                    query = query.filter(Order.numero_ordine.ilike(f"%{filters['numero_ordine']}%"))
+                if filters.get('date_from'):
+                    date_from = datetime.fromisoformat(filters['date_from'])
+                    query = query.filter(Order.data_consegna >= date_from)
+                if filters.get('date_to'):
+                    date_to = datetime.fromisoformat(filters['date_to'])
+                    date_to = date_to.replace(hour=23, minute=59, second=59)
+                    query = query.filter(Order.data_consegna <= date_to)
+
+            total = query.count()
+
+            # Ordinamento
+            ALLOWED_SORT = {'data_consegna', 'cliente', 'numero_ordine', 'data_ricezione'}
+            if sort_by not in ALLOWED_SORT:
+                sort_by = 'data_consegna'
+            if sort_dir.lower() == 'desc':
+                query = query.order_by(getattr(Order, sort_by).desc())
+            else:
+                query = query.order_by(getattr(Order, sort_by).asc())
+
+            offset = (page - 1) * limit
+            orders = query.offset(offset).limit(limit).all()
+
+            orders_data = []
+            for order in orders:
+                notification = session.query(OrderNotification).filter(
+                    OrderNotification.order_id == order.id
+                ).first()
+                total_time = notification.tempi_totali if notification else "N/A"
+
+                last_step = session.query(ProcessingStep).filter(
+                    ProcessingStep.order_id == order.id,
+                    ProcessingStep.timestamp_fine.isnot(None)
+                ).order_by(ProcessingStep.timestamp_fine.desc()).first()
+                completion_date = last_step.timestamp_fine if last_step else None
+
+                phase_times = ArchiveManager._calculate_phase_times(order.id, session)
+                total_hours = OrderManager._calculate_total_hours(order.id, session)
+                costo_orario = 25.0
+                costo_manodopera = total_hours * costo_orario
+                margine = None
+                margine_pct = None
+                if order.prezzo_quotato and order.prezzo_quotato > 0:
+                    margine = order.prezzo_quotato - costo_manodopera
+                    margine_pct = round((margine / order.prezzo_quotato) * 100, 1)
+
+                # File PDF allegato
+                pdf_file = session.query(OrderFile).filter(
+                    OrderFile.order_id == order.id,
+                    OrderFile.file_type == 'PDF'
+                ).first()
+
+                orders_data.append({
+                    'id': order.id,
+                    'numero_ordine': order.numero_ordine or order.id[:8],
+                    'cliente': order.cliente,
+                    'data_consegna': order.data_consegna.isoformat() if order.data_consegna else None,
+                    'data_ricezione': order.data_ricezione.isoformat() if order.data_ricezione else None,
+                    'data_completamento': completion_date.isoformat() if completion_date else None,
+                    'tempo_totale': total_time,
+                    'prezzo_quotato': order.prezzo_quotato,
+                    'costo_manodopera': round(costo_manodopera, 2),
+                    'margine': round(margine, 2) if margine is not None else None,
+                    'margine_pct': margine_pct,
+                    'phase_times': phase_times,
+                    'note': order.note or '',
+                    'has_pdf': pdf_file is not None,
+                    # Dati bozza DDT/fattura (se salvati in precedenza)
+                    'numero_ddt': order.numero_ddt or '',
+                    'data_ddt': order.data_ddt.isoformat() if order.data_ddt else '',
+                    'numero_fattura': order.numero_fattura or '',
+                    'data_fattura': order.data_fattura.isoformat() if order.data_fattura else '',
+                    'note_chiusura': order.note_chiusura or '',
+                })
+
+            total_pages = (total + limit - 1) // limit if total > 0 else 1
+
+            return {
+                'orders': orders_data,
+                'total': total,
+                'page': page,
+                'pages': total_pages
+            }
+        finally:
+            session.close()
+
+    @staticmethod
+    def get_count() -> int:
+        """Ritorna il conteggio ordini DA_FATTURARE (per badge)"""
+        session = get_session()
+        try:
+            return session.query(Order).filter(
+                Order.status == "DA_FATTURARE",
+                Order.is_deleted == False,
+                Order.parent_order_id.is_(None)
+            ).count()
+        finally:
+            session.close()
+
+    @staticmethod
+    def salva_bozza(order_id: str, data: dict) -> dict:
+        """Salva dati DDT/fattura come bozza senza chiudere l'ordine"""
+        session = get_session()
+        try:
+            order = session.query(Order).filter(Order.id == order_id).first()
+            if not order:
+                return {"success": False, "error": "Ordine non trovato"}
+            if order.status not in ("DA_FATTURARE",):
+                return {"success": False, "error": "Ordine non in stato DA_FATTURARE"}
+
+            if 'numero_ddt' in data:
+                order.numero_ddt = data['numero_ddt'] or None
+            if 'data_ddt' in data and data['data_ddt']:
+                order.data_ddt = datetime.fromisoformat(data['data_ddt'])
+            elif 'data_ddt' in data:
+                order.data_ddt = None
+            if 'numero_fattura' in data:
+                order.numero_fattura = data['numero_fattura'] or None
+            if 'data_fattura' in data and data['data_fattura']:
+                order.data_fattura = datetime.fromisoformat(data['data_fattura'])
+            elif 'data_fattura' in data:
+                order.data_fattura = None
+            if 'note_chiusura' in data:
+                order.note_chiusura = data['note_chiusura'] or None
+
+            session.commit()
+            return {"success": True, "order_id": order_id}
+
+        except Exception as e:
+            session.rollback()
+            return {"success": False, "error": str(e)}
+        finally:
+            session.close()
+
+    @staticmethod
+    def chiudi_ordine(order_id: str, data: dict, user_id: str) -> dict:
+        """Chiude ordine amministrativamente — DDT/fattura + status → CHIUSO"""
+        session = get_session()
+        try:
+            order = session.query(Order).filter(Order.id == order_id).first()
+            if not order:
+                return {"success": False, "error": "Ordine non trovato"}
+            if order.status not in ("DA_FATTURARE",):
+                return {"success": False, "error": "Ordine non in stato DA_FATTURARE"}
+
+            now = datetime.utcnow()
+
+            # Salva dati amministrativi
+            if data.get('numero_ddt'):
+                order.numero_ddt = data['numero_ddt']
+            if data.get('data_ddt'):
+                order.data_ddt = datetime.fromisoformat(data['data_ddt'])
+            if data.get('numero_fattura'):
+                order.numero_fattura = data['numero_fattura']
+            if data.get('data_fattura'):
+                order.data_fattura = datetime.fromisoformat(data['data_fattura'])
+            if data.get('note_chiusura'):
+                order.note_chiusura = data['note_chiusura']
+
+            order.data_chiusura_amministrativa = now
+            order.chiuso_da = user_id
+            order.status = "CHIUSO"
+
+            session.commit()
+            return {
+                "success": True,
+                "order_id": order_id,
+                "status": "CHIUSO",
+                "data_chiusura": now.isoformat()
+            }
+
+        except Exception as e:
+            session.rollback()
+            return {"success": False, "error": str(e)}
+        finally:
+            session.close()
+
+    @staticmethod
+    def riapri_ordine(order_id: str) -> dict:
+        """Riapre un ordine CHIUSO riportandolo a DA_FATTURARE"""
+        session = get_session()
+        try:
+            order = session.query(Order).filter(Order.id == order_id).first()
+            if not order:
+                return {"success": False, "error": "Ordine non trovato"}
+            if order.status != "CHIUSO":
+                return {"success": False, "error": "Solo ordini CHIUSO possono essere riaperti"}
+
+            order.status = "DA_FATTURARE"
+            order.data_chiusura_amministrativa = None
+            order.chiuso_da = None
+
+            session.commit()
+            return {"success": True, "order_id": order_id, "status": "DA_FATTURARE"}
+
+        except Exception as e:
+            session.rollback()
+            return {"success": False, "error": str(e)}
         finally:
             session.close()
 
@@ -2566,8 +2802,9 @@ class KPIManager:
 
             # === RIEPILOGO ===
             all_orders = session.query(Order).all()
-            ordini_attivi = sum(1 for o in all_orders if o.status not in ('COMPLETATO', 'SPEDITO'))
-            completati_oggi = sum(1 for o in all_orders if o.status == 'COMPLETATO' and
+            _STATI_FINALI = ('COMPLETATO', 'DA_FATTURARE', 'CHIUSO', 'SPEDITO')
+            ordini_attivi = sum(1 for o in all_orders if o.status not in _STATI_FINALI)
+            completati_oggi = sum(1 for o in all_orders if o.status in _STATI_FINALI and
                 session.query(ProcessingStep).filter(
                     ProcessingStep.order_id == o.id,
                     ProcessingStep.timestamp_fine != None,
@@ -2575,10 +2812,10 @@ class KPIManager:
                 ).first() is not None)
             in_ritardo = sum(1 for o in all_orders
                 if o.data_consegna and o.data_consegna < now
-                and o.status not in ('COMPLETATO', 'SPEDITO'))
-            completati_totali = sum(1 for o in all_orders if o.status == 'COMPLETATO')
+                and o.status not in _STATI_FINALI)
+            completati_totali = sum(1 for o in all_orders if o.status in _STATI_FINALI)
             completati_in_tempo = sum(1 for o in all_orders
-                if o.status == 'COMPLETATO' and o.data_consegna
+                if o.status in _STATI_FINALI and o.data_consegna
                 and any(s.timestamp_fine and s.timestamp_fine <= o.data_consegna
                     for s in session.query(ProcessingStep).filter(ProcessingStep.order_id == o.id).all()))
             efficienza = round((completati_in_tempo / completati_totali * 100) if completati_totali > 0 else 100)
@@ -2697,7 +2934,7 @@ class KPIManager:
                 # In coda: ordini con fase_corrente = questa fase, senza step attivo
                 in_coda_orders = session.query(Order).filter(
                     Order.fase_corrente == fase_nome,
-                    Order.status.notin_(['COMPLETATO', 'SPEDITO'])
+                    Order.status.notin_(['COMPLETATO', 'DA_FATTURARE', 'CHIUSO', 'SPEDITO'])
                 ).all()
                 active_in_fase = session.query(ProcessingStep).filter(
                     ProcessingStep.fase == fase_nome,
@@ -3154,7 +3391,7 @@ class SupportManager:
             order = session.query(Order).filter(Order.id == order_id).first()
             if not order:
                 return {'success': False, 'error': 'Ordine non trovato'}
-            if order.status == 'COMPLETATO':
+            if order.status in ('COMPLETATO', 'DA_FATTURARE', 'CHIUSO'):
                 return {'success': False, 'error': 'Ordine già completato'}
 
             # Verifica duplicati attivi

--- a/app/backend/models.py
+++ b/app/backend/models.py
@@ -37,6 +37,15 @@ class Order(Base):
 
     note = Column(Text)
     is_deleted = Column(Boolean, default=False)  # Soft delete — mai cancellare fisicamente
+
+    # Chiusura amministrativa (DDT / Fattura)
+    numero_ddt = Column(String, nullable=True)
+    data_ddt = Column(DateTime, nullable=True)
+    numero_fattura = Column(String, nullable=True)
+    data_fattura = Column(DateTime, nullable=True)
+    note_chiusura = Column(Text, nullable=True)
+    data_chiusura_amministrativa = Column(DateTime, nullable=True)
+    chiuso_da = Column(String, nullable=True)  # user_id di chi ha chiuso
     parent_order_id = Column(String, ForeignKey('orders.id'), nullable=True)  # ID ordine padre (per lotti)
     lotto_numero = Column(Integer, default=0)  # 0 = ordine normale, 1+ = lotto
     lotto_nome = Column(String, nullable=True)  # Nome personalizzato del lotto (es. "Pezzi grandi")
@@ -365,5 +374,35 @@ def initialize_database():
                 conn.execute(text('ALTER TABLE orders ADD COLUMN lotto_nome TEXT'))
                 logger.info('Aggiunta colonna lotto_nome a orders')
             conn.commit()
+
+    # Migrazione: aggiunge colonne chiusura amministrativa a orders
+    if 'orders' in insp.get_table_names():
+        existing_orders = [c['name'] for c in insp.get_columns('orders')]
+        new_order_cols = {
+            'numero_ddt': 'TEXT',
+            'data_ddt': 'DATETIME',
+            'numero_fattura': 'TEXT',
+            'data_fattura': 'DATETIME',
+            'note_chiusura': 'TEXT',
+            'data_chiusura_amministrativa': 'DATETIME',
+            'chiuso_da': 'TEXT',
+        }
+        with engine.connect() as conn:
+            for col, col_type in new_order_cols.items():
+                if col not in existing_orders:
+                    conn.execute(text(f'ALTER TABLE orders ADD COLUMN {col} {col_type}'))
+                    logger.info('Aggiunta colonna %s a orders', col)
+            conn.commit()
+
+    # Migrazione: ordini COMPLETATO esistenti → DA_FATTURARE
+    if 'orders' in insp.get_table_names():
+        with engine.connect() as conn:
+            migrated = conn.execute(text(
+                "UPDATE orders SET status = 'DA_FATTURARE' "
+                "WHERE status = 'COMPLETATO' AND data_chiusura_amministrativa IS NULL"
+            )).rowcount
+            conn.commit()
+            if migrated:
+                logger.info('Migrati %d ordini COMPLETATO → DA_FATTURARE', migrated)
 
     seed_users()

--- a/app/frontend/approva-ordine.html
+++ b/app/frontend/approva-ordine.html
@@ -387,6 +387,8 @@ h1 {
 .badge-SALDATURA { background: #fee2e2; color: #991b1b; }
 .badge-PULIZIA { background: #d1fae5; color: #065f46; }
 .badge-COMPLETATO { background: #dcfce7; color: #166534; }
+.badge-DA_FATTURARE { background: #e0f2fe; color: #0369a1; }
+.badge-CHIUSO { background: #dcfce7; color: #166534; }
 .badge-PARZIALE { background: #fef9c3; color: #854d0e; }
 
 .order-meta { font-size: 11px; color: var(--text-secondary); line-height: 1.4; }
@@ -2535,7 +2537,7 @@ function renderDetailPanel(order) {
               ` : ''}
             </div>
           `).join('')}
-          ${order.status === 'COMPLETATO' ? (() => {
+          ${['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status) ? (() => {
             const executedFasi = new Set(steps.map(s => s.fase));
             return ['LASER','PIEGA','SALDATURA','PULIZIA'].filter(f => !executedFasi.has(f)).map(f =>
               `<div class="storico-item" style="opacity:0.5;">
@@ -3274,7 +3276,7 @@ async function openForceDelegModal() {
   // Popola ordini
   const orderSelect = document.getElementById('force-deleg-order');
   orderSelect.innerHTML = '<option value="">Seleziona ordine...</option>';
-  allOrders.filter(o => o.status !== 'COMPLETATO' && o.status !== 'SPEDITO').forEach(o => {
+  allOrders.filter(o => !['COMPLETATO','DA_FATTURARE','CHIUSO','SPEDITO'].includes(o.status)).forEach(o => {
     orderSelect.innerHTML += `<option value="${o.id}">${escapeHtml(o.cliente)} — #${escapeHtml(o.numero_ordine || o.id.substring(0,8))} (${o.fase_corrente})</option>`;
   });
 
@@ -3358,7 +3360,7 @@ async function openForceSupportModal() {
     ]);
     const ordersData = await ordersResp.json();
     const usersData = await usersResp.json();
-    const orders = (ordersData.orders || []).filter(o => o.status !== 'COMPLETATO');
+    const orders = (ordersData.orders || []).filter(o => !['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status));
     const users = (usersData.users || []).filter(u => u.is_active !== false && u.id !== 'elena-impiegata');
 
     const orderSelect = document.getElementById('force-support-order');
@@ -3485,7 +3487,7 @@ async function capoFetchArchPage() {
         <div style="font-size:18px;font-weight:700;">${r.total}</div>
       </div>`;
 
-    const faseColors = { LASER:'#ef4444', PIEGA:'#f59e0b', SALDATURA:'#3b82f6', PULIZIA:'#8b5cf6', COMPLETATO:'#22c55e' };
+    const faseColors = { LASER:'#ef4444', PIEGA:'#f59e0b', SALDATURA:'#3b82f6', PULIZIA:'#8b5cf6', COMPLETATO:'#22c55e', DA_FATTURARE:'#0ea5e9', CHIUSO:'#22c55e' };
     const tbody = document.getElementById('capo-arch-tbody');
     if (!r.orders || r.orders.length === 0) {
       tbody.innerHTML = '<tr><td colspan="6"><div style="text-align:center;padding:48px 24px;"><div style="font-size:48px;margin-bottom:12px;opacity:0.3;">📋</div><div style="font-size:15px;font-weight:600;color:var(--text-secondary);">Nessun ordine completato</div><div style="font-size:13px;color:var(--text-secondary);margin-top:4px;opacity:0.7;">Gli ordini completati appariranno qui</div></div></td></tr>';
@@ -3501,7 +3503,7 @@ async function capoFetchArchPage() {
           <td style="padding:10px 14px;border-top:1px solid var(--border);">${consegna}</td>
           <td style="padding:10px 14px;border-top:1px solid var(--border);font-weight:500;color:var(--ls-green);">${o.tempo_totale||'N/A'}</td>
           <td style="padding:10px 14px;border-top:1px solid var(--border);">${chips||'-'}</td>
-          <td style="padding:10px 14px;border-top:1px solid var(--border);"><span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:700;color:white;background:${o.status==='COMPLETATO'?'#22c55e':'#f59e0b'}">${o.status}</span></td>
+          <td style="padding:10px 14px;border-top:1px solid var(--border);"><span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:700;color:white;background:${['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status)?'#22c55e':'#f59e0b'}">${o.status}</span></td>
         </tr>`;
       }).join('');
     }

--- a/app/frontend/archivio.html
+++ b/app/frontend/archivio.html
@@ -992,10 +992,12 @@ textarea.form-input { resize: vertical; min-height: 80px; padding: 10px 12px; he
           <th>Quotato</th>
           <th>Costo</th>
           <th>Margine</th>
+          <th>DDT</th>
+          <th>Fattura</th>
         </tr>
       </thead>
       <tbody id="table-body">
-        <tr class="empty-row"><td colspan="10">Caricamento...</td></tr>
+        <tr class="empty-row"><td colspan="12">Caricamento...</td></tr>
       </tbody>
     </table>
   </div>
@@ -1065,7 +1067,7 @@ function renderTable(orders) {
   const tbody = document.getElementById('table-body');
 
   if (orders.length === 0) {
-    tbody.innerHTML = '<tr class="empty-row"><td colspan="10">Nessun ordine trovato</td></tr>';
+    tbody.innerHTML = '<tr class="empty-row"><td colspan="12">Nessun ordine trovato</td></tr>';
     return;
   }
 
@@ -1121,6 +1123,9 @@ function renderTable(orders) {
       });
     }
 
+    const ddtStr = o.numero_ddt || '\u2014';
+    const fattStr = o.numero_fattura || '\u2014';
+
     return `<tr>
       <td class="order-id">${escapeHtml(o.numero_ordine || o.id?.substring(0, 8))}${lottiTag}</td>
       <td>${escapeHtml(o.cliente)}</td>
@@ -1132,6 +1137,8 @@ function renderTable(orders) {
       <td>${quotato}</td>
       <td>${costoStr}</td>
       <td><span class="margin-badge ${marginClass}">${marginStr}</span></td>
+      <td style="font-size:12px;">${ddtStr}</td>
+      <td style="font-size:12px;">${fattStr}</td>
     </tr>${lottiRows}`;
   }).join('');
 }

--- a/app/frontend/dettaglio-ordine.html
+++ b/app/frontend/dettaglio-ordine.html
@@ -1210,7 +1210,7 @@ function renderRight() {
   let statusText = 'Ricevuto';
   let statusClass = 'waiting';
   if (activeStep) { statusText = `In lavorazione: ${activeStep.fase}`; statusClass = 'active'; }
-  else if (order.status === 'COMPLETATO') { statusText = 'Completato'; statusClass = 'done'; }
+  else if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status)) { statusText = order.status === 'CHIUSO' ? 'Chiuso' : order.status === 'DA_FATTURARE' ? 'Da Fatturare' : 'Completato'; statusClass = 'done'; }
   else if (phase && phase !== 'COMPLETATO') { statusText = `In attesa fase: ${phase}`; statusClass = 'waiting'; }
 
   let html = `
@@ -1236,7 +1236,7 @@ function renderRight() {
       <div class="action-title">Cosa vuoi fare?</div>
       <div class="action-subtitle">Scegli la prossima azione per questo ordine</div>
       <div class="action-btns">
-        ${!activeStep && order.status !== 'COMPLETATO' ? `
+        ${!activeStep && !['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status) ? `
           <button class="phase-btn laser" onclick="moveToPhase('LASER')">
             <span>&#9889;</span>
             <span class="phase-btn-label">Manda al Laser</span>

--- a/app/frontend/impiegata.html
+++ b/app/frontend/impiegata.html
@@ -1171,6 +1171,117 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
   animation: spin 0.6s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* === FATTURARE TAB === */
+.fatt-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 100px;
+  background: #ef4444;
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+.fatt-container { max-width: 1200px; margin: 0 auto; padding: 20px 0; }
+.fatt-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.fatt-header h2 { font-size: 20px; font-weight: 800; }
+.fatt-filters {
+  display: flex; gap: 12px; align-items: flex-end; flex-wrap: wrap;
+  margin-bottom: 20px; padding: 16px; background: var(--white);
+  border: 1px solid var(--border); border-radius: 12px;
+}
+.fatt-filters .filter-group { display: flex; flex-direction: column; gap: 4px; }
+.fatt-filters label { font-size: 11px; font-weight: 600; color: var(--gray-text); text-transform: uppercase; }
+.fatt-filters input, .fatt-filters select {
+  padding: 8px 12px; border: 1px solid var(--border); border-radius: 8px;
+  font-size: 13px; font-family: inherit; min-width: 140px;
+}
+.fatt-stats { display: flex; gap: 16px; margin-bottom: 16px; }
+.fatt-stat { background: var(--white); border: 1px solid var(--border); border-radius: 8px; padding: 12px 20px; display: flex; flex-direction: column; gap: 2px; }
+.fatt-stat-label { font-size: 11px; color: var(--gray-text); text-transform: uppercase; font-weight: 600; }
+.fatt-stat-value { font-size: 18px; font-weight: 700; color: var(--black); }
+.fatt-table {
+  width: 100%; border-collapse: collapse; font-size: 13px;
+  background: var(--white); border: 1px solid var(--border); border-radius: 12px; overflow: hidden;
+}
+.fatt-table thead { background: #f1f5f9; }
+.fatt-table th {
+  text-align: left; padding: 12px 14px; font-size: 11px; font-weight: 700;
+  color: var(--gray-text); text-transform: uppercase; letter-spacing: 0.5px;
+  cursor: pointer; user-select: none; white-space: nowrap;
+}
+.fatt-table th:hover { color: var(--green); }
+.fatt-table td { padding: 10px 14px; border-top: 1px solid var(--border); }
+.fatt-table tbody tr { transition: background 0.15s; cursor: pointer; }
+.fatt-table tbody tr:hover { background: rgba(26,122,72,0.06); }
+.fatt-table tbody tr.expanded { background: rgba(26,122,72,0.04); }
+.fatt-expand-row { display: none; }
+.fatt-expand-row.active { display: table-row; }
+.fatt-expand-cell { padding: 0 !important; border-top: none !important; }
+.fatt-expand-content {
+  padding: 20px 24px; background: #f9fafb; border-top: 1px solid var(--border);
+}
+.fatt-detail-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px;
+}
+.fatt-detail-section h4 { font-size: 13px; font-weight: 700; margin-bottom: 10px; color: var(--black); }
+.fatt-detail-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 13px; }
+.fatt-detail-row .label { color: var(--gray-text); }
+.fatt-detail-row .value { font-weight: 600; }
+.fatt-form-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 16px;
+}
+.fatt-form-group { display: flex; flex-direction: column; gap: 4px; }
+.fatt-form-group label { font-size: 11px; font-weight: 600; color: var(--gray-text); text-transform: uppercase; }
+.fatt-form-group input, .fatt-form-group textarea {
+  padding: 8px 12px; border: 1px solid var(--border); border-radius: 8px;
+  font-size: 13px; font-family: inherit;
+}
+.fatt-form-group textarea { resize: vertical; min-height: 60px; }
+.fatt-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 12px; }
+.fatt-btn {
+  padding: 8px 20px; border: none; border-radius: 8px; font-size: 13px;
+  font-weight: 600; cursor: pointer; transition: all 0.2s;
+}
+.fatt-btn-save { background: #e2e8f0; color: #334155; }
+.fatt-btn-save:hover { background: #cbd5e1; }
+.fatt-btn-close { background: var(--green); color: white; }
+.fatt-btn-close:hover { background: var(--green-light); }
+.fatt-btn-pdf { background: #dbeafe; color: #1e40af; }
+.fatt-btn-pdf:hover { background: #bfdbfe; }
+.fatt-pagination {
+  display: flex; justify-content: center; align-items: center; gap: 8px; margin-top: 16px;
+}
+.fatt-pagination button {
+  padding: 6px 14px; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--white); cursor: pointer; font-size: 13px; transition: all 0.25s;
+}
+.fatt-pagination button:hover:not(:disabled) { border-color: var(--green); color: var(--green); }
+.fatt-pagination button:disabled { opacity: 0.4; cursor: default; }
+.fatt-pagination span { font-size: 13px; color: var(--gray-text); }
+.fatt-fase-badge {
+  display: inline-block; padding: 2px 8px; border-radius: 100px;
+  font-size: 10px; font-weight: 700; color: white; letter-spacing: 0.3px;
+}
+/* Confirm overlay */
+.fatt-confirm-overlay {
+  display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.5); z-index: 3000; align-items: center; justify-content: center;
+}
+.fatt-confirm-overlay.active { display: flex; }
+.fatt-confirm-box {
+  background: white; border-radius: 16px; padding: 32px; max-width: 420px; width: 90%;
+  text-align: center; box-shadow: 0 20px 60px rgba(0,0,0,0.15);
+}
+.fatt-confirm-box h3 { margin-bottom: 12px; font-size: 18px; }
+.fatt-confirm-box p { color: var(--gray-text); font-size: 14px; margin-bottom: 24px; }
+.fatt-confirm-btns { display: flex; gap: 12px; justify-content: center; }
 </style>
 </head>
 <body>
@@ -1218,6 +1329,7 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
   <div class="tab-item active" data-tab="carica" onclick="switchTab('carica')">Carica Ordine</div>
   <div class="tab-item" data-tab="calendario" onclick="switchTab('calendario')">Calendario</div>
   <div class="tab-item" data-tab="ordini" onclick="switchTab('ordini')">Ordini</div>
+  <div class="tab-item" data-tab="fatturare" onclick="switchTab('fatturare')">Ordini da Fatturare <span class="fatt-badge" id="fatt-badge" style="display:none;">0</span></div>
   <div class="tab-item" data-tab="archivio" onclick="switchTab('archivio')">Archivio</div>
   <div class="tab-item" data-tab="clienti" onclick="switchTab('clienti')">Clienti</div>
   <div class="tab-item" data-tab="backup" onclick="switchTab('backup')">Backup</div>
@@ -1323,7 +1435,8 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
       <button class="chip active" data-filter="status" data-value="" onclick="setFilter(this,'status')">Tutti</button>
       <button class="chip" data-filter="status" data-value="RICEVUTO" onclick="setFilter(this,'status')">Ricevuto</button>
       <button class="chip" data-filter="status" data-value="IN_LAVORAZIONE" onclick="setFilter(this,'status')">In Lavorazione</button>
-      <button class="chip" data-filter="status" data-value="COMPLETATO" onclick="setFilter(this,'status')">Completato</button>
+      <button class="chip" data-filter="status" data-value="DA_FATTURARE" onclick="setFilter(this,'status')">Da Fatturare</button>
+      <button class="chip" data-filter="status" data-value="CHIUSO" onclick="setFilter(this,'status')">Chiuso</button>
       <button class="chip" data-filter="status" data-value="PARZIALE" onclick="setFilter(this,'status')">Parziale</button>
     </div>
     <div class="filter-row">
@@ -1367,6 +1480,66 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
 </div>
 
 <!-- ===================== TAB 4: ARCHIVIO ===================== -->
+<!-- ===================== TAB: ORDINI DA FATTURARE ===================== -->
+<div class="tab-panel" id="panel-fatturare">
+  <div class="fatt-container">
+    <div class="fatt-header">
+      <h2>Ordini da Fatturare</h2>
+    </div>
+
+    <div class="fatt-filters">
+      <div class="filter-group">
+        <label>Cliente</label>
+        <input type="text" id="fatt-filter-cliente" placeholder="Cerca cliente..." oninput="debounceFattLoad()">
+      </div>
+      <div class="filter-group">
+        <label>N. Ordine</label>
+        <input type="text" id="fatt-filter-ordine" placeholder="Cerca ordine..." oninput="debounceFattLoad()">
+      </div>
+      <div class="filter-group">
+        <label>Data da</label>
+        <input type="date" id="fatt-filter-from" onchange="loadFatturare()">
+      </div>
+      <div class="filter-group">
+        <label>Data a</label>
+        <input type="date" id="fatt-filter-to" onchange="loadFatturare()">
+      </div>
+      <button class="btn-filter" onclick="resetFattFilters()">Reset filtri</button>
+    </div>
+
+    <div class="fatt-stats" id="fatt-stats"></div>
+
+    <table class="fatt-table">
+      <thead>
+        <tr>
+          <th onclick="sortFatt('numero_ordine')">Ordine &#8597;</th>
+          <th onclick="sortFatt('cliente')">Cliente &#8597;</th>
+          <th onclick="sortFatt('data_consegna')">Consegna &#8597;</th>
+          <th>Tempo Prod.</th>
+          <th>Fasi</th>
+          <th>Stato DDT</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="fatt-tbody"></tbody>
+    </table>
+
+    <div class="fatt-pagination" id="fatt-pagination"></div>
+  </div>
+</div>
+
+<!-- CONFERMA CHIUSURA MODALE -->
+<div class="fatt-confirm-overlay" id="fatt-confirm-modal" onclick="if(event.target===this)closeFattConfirm()">
+  <div class="fatt-confirm-box">
+    <h3>Conferma Chiusura Ordine</h3>
+    <p id="fatt-confirm-text">Sei sicura di voler chiudere questo ordine?</p>
+    <div class="fatt-confirm-btns">
+      <button class="fatt-btn fatt-btn-save" onclick="closeFattConfirm()">Annulla</button>
+      <button class="fatt-btn fatt-btn-close" id="fatt-confirm-btn" onclick="confirmChiudiOrdine()">Chiudi Ordine</button>
+    </div>
+  </div>
+</div>
+
 <div class="tab-panel" id="panel-archivio">
   <div class="archivio-container">
     <div class="archivio-header">
@@ -1410,7 +1583,8 @@ button:focus-visible, select:focus-visible, input:focus-visible, a:focus-visible
           <th onclick="sortArchive('cliente')">Cliente &#8597;</th>
           <th onclick="sortArchive('data_consegna')">Consegna &#8597;</th>
           <th>Tempo Totale</th>
-          <th>Fasi</th>
+          <th>DDT</th>
+          <th>Fattura</th>
           <th>Stato</th>
         </tr>
       </thead>
@@ -1608,10 +1782,12 @@ function getOrderCompletionDate(order) {
 // ===========================
 const faseColors = {
   LASER: '#3b82f6', PIEGA: '#f59e0b', SALDATURA: '#ef4444',
-  PULIZIA: '#8b5cf6', COMPLETATO: '#22c55e', PARZIALE: '#f97316'
+  PULIZIA: '#8b5cf6', COMPLETATO: '#22c55e', DA_FATTURARE: '#0ea5e9', CHIUSO: '#22c55e', PARZIALE: '#f97316'
 };
 
 function getStatusColor(order) {
+  if (order.status === 'CHIUSO') return '#22c55e';
+  if (order.status === 'DA_FATTURARE') return '#0ea5e9';
   if (order.status === 'COMPLETATO') return '#22c55e';
   if (order.status === 'PARZIALE') return '#f97316';
   const today = new Date(); today.setHours(0,0,0,0);
@@ -1623,7 +1799,7 @@ function getStatusColor(order) {
 }
 
 function calculateProgress(order) {
-  if (order.status === 'COMPLETATO') return 100;
+  if (order.status === 'CHIUSO' || order.status === 'DA_FATTURARE' || order.status === 'COMPLETATO') return 100;
   if (order.status === 'PARZIALE') return 85;
   const steps = order.processing_steps || [];
   const anyStarted = steps.some(s => s.timestamp_inizio);
@@ -1688,6 +1864,7 @@ function switchTab(tabId) {
   panel.style.animation = 'tabFadeIn 0.2s ease-out';
   if (tabId === 'calendario') loadCalendar();
   if (tabId === 'ordini') loadOrdersList();
+  if (tabId === 'fatturare') loadFatturare();
   if (tabId === 'archivio') { loadArchiveFilters(); loadArchive(); }
   if (tabId === 'clienti') loadClienti();
   if (tabId === 'backup') { loadBackupSettings(); loadBackupList(); }
@@ -2049,7 +2226,7 @@ function renderOrdersTable() {
     const now = Date.now();
     const msLimit = giorniMax * 24 * 60 * 60 * 1000;
     filtered = filtered.filter(o => {
-      if (o.status !== 'COMPLETATO' && o.status !== 'PARZIALE') return true;
+      if (!['COMPLETATO','DA_FATTURARE','CHIUSO','PARZIALE'].includes(o.status)) return true;
       const completedAt = getOrderCompletionDate(o);
       if (!completedAt) return true; // nessuna data = mostra
       return (now - completedAt.getTime()) <= msLimit;
@@ -2432,6 +2609,307 @@ async function logout() {
 }
 
 // ===========================
+// ===========================
+// TAB: ORDINI DA FATTURARE
+// ===========================
+let fattPage = 1;
+let fattSortBy = 'data_consegna';
+let fattSortDir = 'asc';
+let fattExpandedId = null;
+let fattConfirmOrderId = null;
+let fattDebounceTimer = null;
+const fattFaseColors = { LASER: '#ef4444', PIEGA: '#f59e0b', SALDATURA: '#3b82f6', PULIZIA: '#8b5cf6' };
+
+function debounceFattLoad() {
+  clearTimeout(fattDebounceTimer);
+  fattDebounceTimer = setTimeout(() => loadFatturare(), 300);
+}
+
+async function loadFatturare() {
+  fattPage = 1;
+  await fetchFattPage();
+  updateFattBadge();
+}
+
+async function updateFattBadge() {
+  try {
+    const res = await fetch(`${API_URL}/api/ordini-da-fatturare/count`);
+    const data = await res.json();
+    const badge = document.getElementById('fatt-badge');
+    if (data.success && data.count > 0) {
+      badge.textContent = data.count;
+      badge.style.display = 'inline-flex';
+    } else {
+      badge.style.display = 'none';
+    }
+  } catch (e) { console.error('updateFattBadge error:', e); }
+}
+
+function getFattFilterParams() {
+  const params = new URLSearchParams();
+  const cliente = document.getElementById('fatt-filter-cliente').value.trim();
+  const ordine = document.getElementById('fatt-filter-ordine').value.trim();
+  const dateFrom = document.getElementById('fatt-filter-from').value;
+  const dateTo = document.getElementById('fatt-filter-to').value;
+  if (cliente) params.set('cliente', cliente);
+  if (ordine) params.set('numero_ordine', ordine);
+  if (dateFrom) params.set('date_from', dateFrom);
+  if (dateTo) params.set('date_to', dateTo);
+  return params;
+}
+
+async function fetchFattPage() {
+  try {
+    const params = getFattFilterParams();
+    params.set('page', fattPage);
+    params.set('limit', 20);
+    params.set('sort_by', fattSortBy);
+    params.set('sort_dir', fattSortDir);
+
+    const res = await fetch(`${API_URL}/api/ordini-da-fatturare?${params}`);
+    const data = await res.json();
+    if (!data.success) { showMessage('Errore caricamento ordini da fatturare', 'error'); return; }
+
+    const result = data.data;
+    document.getElementById('fatt-stats').innerHTML = `
+      <div class="fatt-stat">
+        <span class="fatt-stat-label">Ordini da fatturare</span>
+        <span class="fatt-stat-value">${result.total}</span>
+      </div>
+    `;
+    renderFattTable(result.orders);
+    renderFattPagination(result);
+  } catch (e) {
+    console.error('fetchFattPage error:', e);
+    showMessage('Errore di connessione', 'error');
+  }
+}
+
+function renderFattTable(orders) {
+  const tbody = document.getElementById('fatt-tbody');
+  if (!orders || orders.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="7"><div style="text-align:center;padding:48px 24px;"><div style="font-size:48px;margin-bottom:12px;opacity:0.3;">&#9989;</div><div style="font-size:15px;font-weight:600;color:var(--gray-text);">Nessun ordine da fatturare</div></div></td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = orders.map(o => {
+    const phases = o.phase_times || {};
+    const phaseChips = Object.entries(phases).map(([fase, tempo]) =>
+      `<span class="fatt-fase-badge" style="background:${fattFaseColors[fase] || '#888'}" title="${tempo}">${fase}</span>`
+    ).join(' ');
+    const consegna = o.data_consegna ? new Date(o.data_consegna).toLocaleDateString('it-IT') : '';
+    const hasDdt = o.numero_ddt ? 'Bozza' : '-';
+    const ddtStyle = o.numero_ddt ? 'color:#f59e0b;font-weight:600;' : 'color:var(--gray-muted);';
+    const isExpanded = fattExpandedId === o.id;
+
+    return `<tr class="${isExpanded ? 'expanded' : ''}" onclick="toggleFattExpand('${o.id}')">
+      <td style="font-weight:600;">${escapeHtml(o.numero_ordine || o.id.substring(0,8))}</td>
+      <td>${escapeHtml(o.cliente)}</td>
+      <td>${consegna}</td>
+      <td style="font-weight:500;color:var(--green);">${o.tempo_totale || 'N/A'}</td>
+      <td>${phaseChips || '-'}</td>
+      <td style="${ddtStyle}">${hasDdt}</td>
+      <td style="text-align:center;">&#9660;</td>
+    </tr>
+    <tr class="fatt-expand-row ${isExpanded ? 'active' : ''}" id="fatt-expand-${o.id}">
+      <td colspan="7" class="fatt-expand-cell">
+        <div class="fatt-expand-content">
+          <div class="fatt-detail-grid">
+            <div class="fatt-detail-section">
+              <h4>Dettagli Ordine</h4>
+              <div class="fatt-detail-row"><span class="label">Cliente</span><span class="value">${escapeHtml(o.cliente)}</span></div>
+              <div class="fatt-detail-row"><span class="label">N. Ordine</span><span class="value">${escapeHtml(o.numero_ordine || '-')}</span></div>
+              <div class="fatt-detail-row"><span class="label">Data Consegna</span><span class="value">${consegna}</span></div>
+              <div class="fatt-detail-row"><span class="label">Data Completamento</span><span class="value">${o.data_completamento ? new Date(o.data_completamento).toLocaleDateString('it-IT') : '-'}</span></div>
+              <div class="fatt-detail-row"><span class="label">Tempo Produzione</span><span class="value">${o.tempo_totale || 'N/A'}</span></div>
+              ${o.note ? `<div class="fatt-detail-row"><span class="label">Note</span><span class="value">${escapeHtml(o.note)}</span></div>` : ''}
+            </div>
+            <div class="fatt-detail-section">
+              <h4>Costi e Margini</h4>
+              <div class="fatt-detail-row"><span class="label">Prezzo Quotato</span><span class="value">${o.prezzo_quotato ? '€ ' + o.prezzo_quotato.toFixed(2) : '-'}</span></div>
+              <div class="fatt-detail-row"><span class="label">Costo Manodopera</span><span class="value">€ ${o.costo_manodopera.toFixed(2)}</span></div>
+              <div class="fatt-detail-row"><span class="label">Margine</span><span class="value" style="color:${o.margine && o.margine >= 0 ? 'var(--green)' : '#ef4444'}">${o.margine !== null ? '€ ' + o.margine.toFixed(2) + (o.margine_pct !== null ? ' (' + o.margine_pct + '%)' : '') : '-'}</span></div>
+              <div class="fatt-detail-row"><span class="label">Fasi</span><span class="value">${phaseChips || '-'}</span></div>
+              ${o.has_pdf ? `<div style="margin-top:8px;"><button class="fatt-btn fatt-btn-pdf" onclick="event.stopPropagation(); window.open(API_URL+'/api/orders/${o.id}/pdf','_blank')">Vedi PDF Ordine</button></div>` : ''}
+            </div>
+          </div>
+
+          <h4 style="margin-bottom:10px;">Dati Chiusura Amministrativa</h4>
+          <div class="fatt-form-grid">
+            <div class="fatt-form-group">
+              <label>Numero DDT</label>
+              <input type="text" id="fatt-ddt-${o.id}" value="${escapeHtml(o.numero_ddt)}" placeholder="Es: DDT-2026/001" onclick="event.stopPropagation()">
+            </div>
+            <div class="fatt-form-group">
+              <label>Data DDT</label>
+              <input type="date" id="fatt-ddt-date-${o.id}" value="${o.data_ddt ? o.data_ddt.substring(0,10) : ''}" onclick="event.stopPropagation()">
+            </div>
+            <div class="fatt-form-group">
+              <label>Numero Fattura</label>
+              <input type="text" id="fatt-fattura-${o.id}" value="${escapeHtml(o.numero_fattura)}" placeholder="Es: FT-2026/001" onclick="event.stopPropagation()">
+            </div>
+            <div class="fatt-form-group">
+              <label>Data Fattura</label>
+              <input type="date" id="fatt-fattura-date-${o.id}" value="${o.data_fattura ? o.data_fattura.substring(0,10) : ''}" onclick="event.stopPropagation()">
+            </div>
+          </div>
+          <div class="fatt-form-group" style="margin-bottom:0;">
+            <label>Note Chiusura</label>
+            <textarea id="fatt-note-${o.id}" placeholder="Note sulla chiusura amministrativa..." onclick="event.stopPropagation()">${escapeHtml(o.note_chiusura)}</textarea>
+          </div>
+
+          <div class="fatt-actions">
+            <button class="fatt-btn fatt-btn-save" onclick="event.stopPropagation(); salvaBozzaFattura('${o.id}')">Salva Bozza</button>
+            <button class="fatt-btn fatt-btn-close" onclick="event.stopPropagation(); openFattConfirm('${o.id}', '${escapeHtml(o.cliente)}', '${escapeHtml(o.numero_ordine || '')}')">Chiudi Ordine</button>
+          </div>
+        </div>
+      </td>
+    </tr>`;
+  }).join('');
+}
+
+function toggleFattExpand(orderId) {
+  if (fattExpandedId === orderId) {
+    fattExpandedId = null;
+  } else {
+    fattExpandedId = orderId;
+  }
+  // Re-render to toggle expansion
+  fetchFattPage();
+}
+
+function renderFattPagination(result) {
+  const div = document.getElementById('fatt-pagination');
+  if (result.pages <= 1) { div.innerHTML = ''; return; }
+  div.innerHTML = `
+    <button onclick="fattGoPage(${result.page - 1})" ${result.page <= 1 ? 'disabled' : ''}>&#8592; Prec</button>
+    <span>Pagina ${result.page} di ${result.pages}</span>
+    <button onclick="fattGoPage(${result.page + 1})" ${result.page >= result.pages ? 'disabled' : ''}>Succ &#8594;</button>
+  `;
+}
+
+function fattGoPage(page) {
+  fattPage = page;
+  fetchFattPage();
+}
+
+function sortFatt(field) {
+  if (fattSortBy === field) {
+    fattSortDir = fattSortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    fattSortBy = field;
+    fattSortDir = 'asc';
+  }
+  fattPage = 1;
+  fetchFattPage();
+}
+
+function resetFattFilters() {
+  document.getElementById('fatt-filter-cliente').value = '';
+  document.getElementById('fatt-filter-ordine').value = '';
+  document.getElementById('fatt-filter-from').value = '';
+  document.getElementById('fatt-filter-to').value = '';
+  loadFatturare();
+}
+
+function getFattFormData(orderId) {
+  return {
+    numero_ddt: document.getElementById(`fatt-ddt-${orderId}`).value.trim(),
+    data_ddt: document.getElementById(`fatt-ddt-date-${orderId}`).value || '',
+    numero_fattura: document.getElementById(`fatt-fattura-${orderId}`).value.trim(),
+    data_fattura: document.getElementById(`fatt-fattura-date-${orderId}`).value || '',
+    note_chiusura: document.getElementById(`fatt-note-${orderId}`).value.trim(),
+  };
+}
+
+async function salvaBozzaFattura(orderId) {
+  try {
+    const data = getFattFormData(orderId);
+    const res = await fetch(`${API_URL}/api/orders/${orderId}/salva-bozza-fattura`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const result = await res.json();
+    if (result.success) {
+      showMessage('Bozza salvata con successo', 'success');
+    } else {
+      showMessage(result.error || 'Errore salvataggio bozza', 'error');
+    }
+  } catch (e) {
+    console.error('salvaBozzaFattura error:', e);
+    showMessage('Errore di connessione', 'error');
+  }
+}
+
+function openFattConfirm(orderId, cliente, numOrdine) {
+  fattConfirmOrderId = orderId;
+  document.getElementById('fatt-confirm-text').textContent =
+    `Sei sicura di voler chiudere l'ordine ${numOrdine || orderId.substring(0,8)} di ${cliente}? L'ordine verrà spostato in archivio.`;
+  document.getElementById('fatt-confirm-modal').classList.add('active');
+}
+
+function closeFattConfirm() {
+  fattConfirmOrderId = null;
+  document.getElementById('fatt-confirm-modal').classList.remove('active');
+}
+
+async function confirmChiudiOrdine() {
+  if (!fattConfirmOrderId) return;
+  const orderId = fattConfirmOrderId;
+  closeFattConfirm();
+
+  try {
+    const data = getFattFormData(orderId);
+    const currentUser = JSON.parse(localStorage.getItem('currentUser') || '{}');
+    data.user_id = currentUser.id || '';
+
+    const res = await fetch(`${API_URL}/api/orders/${orderId}/chiudi-amministrativo`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const result = await res.json();
+    if (result.success) {
+      showMessage('Ordine chiuso con successo', 'success');
+      fattExpandedId = null;
+      loadFatturare();
+    } else {
+      showMessage(result.error || 'Errore chiusura ordine', 'error');
+    }
+  } catch (e) {
+    console.error('confirmChiudiOrdine error:', e);
+    showMessage('Errore di connessione', 'error');
+  }
+}
+
+async function riapriFattOrdine(orderId) {
+  if (!confirm('Sei sicura di voler riaprire questo ordine? Tornerà negli ordini da fatturare.')) return;
+  try {
+    const currentUser = JSON.parse(localStorage.getItem('currentUser') || '{}');
+    const res = await fetch(`${API_URL}/api/orders/${orderId}/riapri`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: currentUser.id || '' })
+    });
+    const result = await res.json();
+    if (result.success) {
+      showMessage('Ordine riaperto — spostato in "Ordini da Fatturare"', 'success');
+      closeArchDetail();
+      loadArchive();
+      updateFattBadge();
+    } else {
+      showMessage(result.error || 'Errore riapertura', 'error');
+    }
+  } catch (e) {
+    console.error('riapriFattOrdine error:', e);
+    showMessage('Errore di connessione', 'error');
+  }
+}
+
+// Carica badge al boot
+updateFattBadge();
+
 // TAB 4: ARCHIVIO ORDINI
 // ===========================
 let archPage = 1;
@@ -2518,25 +2996,23 @@ const archFaseColors = { LASER: '#ef4444', PIEGA: '#f59e0b', SALDATURA: '#3b82f6
 function renderArchiveTable(orders) {
   const tbody = document.getElementById('arch-tbody');
   if (!orders || orders.length === 0) {
-    tbody.innerHTML = '<tr><td colspan="6"><div style="text-align:center;padding:48px 24px;"><div style="font-size:48px;margin-bottom:12px;opacity:0.3;">📋</div><div style="font-size:15px;font-weight:600;color:var(--gray-text);">Nessun ordine completato trovato</div></div></td></tr>';
+    tbody.innerHTML = '<tr><td colspan="7"><div style="text-align:center;padding:48px 24px;"><div style="font-size:48px;margin-bottom:12px;opacity:0.3;">&#128203;</div><div style="font-size:15px;font-weight:600;color:var(--gray-text);">Nessun ordine in archivio</div></div></td></tr>';
     return;
   }
 
   tbody.innerHTML = orders.map(o => {
-    const phases = o.phase_times || {};
-    const phaseChips = Object.entries(phases).map(([fase, tempo]) =>
-      `<span class="arch-fase-badge" style="background:${archFaseColors[fase] || '#888'}" title="${tempo}">${fase}</span>`
-    ).join(' ');
-
     const consegna = o.data_consegna ? new Date(o.data_consegna).toLocaleDateString('it-IT') : '';
+    const ddtInfo = o.numero_ddt || '-';
+    const fattInfo = o.numero_fattura || '-';
 
     return `<tr onclick="openArchDetail('${o.id}')">
       <td style="font-weight:600;">${o.numero_ordine || o.id.substring(0,8)}</td>
       <td>${o.cliente}</td>
       <td>${consegna}</td>
       <td style="font-weight:500;color:var(--green);">${o.tempo_totale || 'N/A'}</td>
-      <td>${phaseChips || '-'}</td>
-      <td><span class="arch-fase-badge" style="background:${o.status === 'COMPLETATO' ? '#22c55e' : '#f59e0b'}">${o.status}</span></td>
+      <td style="font-size:12px;">${ddtInfo}</td>
+      <td style="font-size:12px;">${fattInfo}</td>
+      <td><span class="arch-fase-badge" style="background:${o.status === 'CHIUSO' ? '#22c55e' : '#f59e0b'}">${o.status === 'CHIUSO' ? 'CHIUSO' : o.status}</span></td>
     </tr>`;
   }).join('');
 }
@@ -2670,7 +3146,7 @@ function renderArchDetail(order) {
     }).join('');
 
     // Aggiungi fasi non necessarie per ordini completati anticipatamente
-    if (order.status === 'COMPLETATO') {
+    if (order.status === 'CHIUSO' || order.status === 'COMPLETATO') {
       const executedFasi = new Set(order.fasi.map(f => f.fase));
       ['LASER','PIEGA','SALDATURA','PULIZIA'].forEach(f => {
         if (!executedFasi.has(f)) {
@@ -2695,6 +3171,17 @@ function renderArchDetail(order) {
       <div class="arch-info-item"><label>Stato</label><span>${order.status}</span></div>
     </div>
     ${order.note ? `<div style="margin-bottom:20px;"><label style="font-size:11px;color:var(--gray-text);text-transform:uppercase;font-weight:600;">Note</label><p style="font-size:13px;margin-top:4px;">${order.note}</p></div>` : ''}
+
+    <div class="arch-phases-title">Chiusura Amministrativa</div>
+    <div class="arch-info-grid" style="margin-bottom:20px;">
+      <div class="arch-info-item"><label>N. DDT</label><span>${order.numero_ddt || '-'}</span></div>
+      <div class="arch-info-item"><label>Data DDT</label><span>${order.data_ddt ? archFormatDate(order.data_ddt) : '-'}</span></div>
+      <div class="arch-info-item"><label>N. Fattura</label><span>${order.numero_fattura || '-'}</span></div>
+      <div class="arch-info-item"><label>Data Fattura</label><span>${order.data_fattura ? archFormatDate(order.data_fattura) : '-'}</span></div>
+      <div class="arch-info-item"><label>Data Chiusura</label><span>${order.data_chiusura_amministrativa ? archFormatDate(order.data_chiusura_amministrativa) : '-'}</span></div>
+      <div class="arch-info-item"><label>Note Chiusura</label><span>${order.note_chiusura || '-'}</span></div>
+    </div>
+
     <div class="arch-phases-title">Dettaglio Fasi</div>
     ${phasesHtml || '<div class="archivio-empty">Nessuna fase registrata</div>'}
     ${(order.support_requests || []).filter(sr => sr.stato === 'accepted').length > 0 ? `
@@ -2705,6 +3192,12 @@ function renderArchDetail(order) {
           <span style="font-size:11px; color:#6b7280;">in supporto a ${escapeHtml(sr.nome_principale)}</span>
         </div>
       `).join('')}
+    ` : ''}
+
+    ${order.status === 'CHIUSO' ? `
+      <div style="margin-top:20px;text-align:right;">
+        <button class="fatt-btn" style="background:#fef2f2;color:#dc2626;border:1px solid #fecaca;" onclick="riapriFattOrdine('${order.id}')">Riapri Ordine</button>
+      </div>
     ` : ''}
   `;
 }

--- a/app/frontend/laser-v2.html
+++ b/app/frontend/laser-v2.html
@@ -1996,7 +1996,7 @@ async function loadStatoOrdini() {
 }
 
 function statoCalcProgress(order) {
-  if (order.status === 'COMPLETATO') return 100;
+  if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status)) return 100;
   if (order.status === 'PARZIALE') return 85;
   const map = { LASER: 10, PIEGA: 35, SALDATURA: 55, PULIZIA: 80, COMPLETATO: 100 };
   const base = map[order.fase_corrente] || 0;
@@ -2018,8 +2018,8 @@ function renderStatoOrdini() {
 
   let filtered = allOrdiniStato.filter(o => {
     // Default (vuoto) = nascondi completati
-    if (!filtroFase && (o.status === 'COMPLETATO' || o.status === 'PARZIALE')) return false;
-    if (filtroFase === 'COMPLETATO' && o.status !== 'COMPLETATO' && o.status !== 'PARZIALE') return false;
+    if (!filtroFase && (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status) || o.status === 'PARZIALE')) return false;
+    if (filtroFase === 'COMPLETATO' && !['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status) && o.status !== 'PARZIALE') return false;
     if (filtroFase && filtroFase !== 'COMPLETATO' && o.fase_corrente !== filtroFase) return false;
     if (search && !o.cliente.toLowerCase().includes(search) && !(o.numero_ordine || '').toLowerCase().includes(search)) return false;
     return true;
@@ -2038,7 +2038,7 @@ function renderStatoOrdini() {
 
   const groups = {};
   filtered.forEach(o => {
-    const fase = (o.status === 'COMPLETATO' || o.status === 'PARZIALE') ? 'COMPLETATO' : (o.fase_corrente || 'LASER');
+    const fase = (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status) || o.status === 'PARZIALE') ? 'COMPLETATO' : (o.fase_corrente || 'LASER');
     if (!groups[fase]) groups[fase] = [];
     groups[fase].push(o);
   });

--- a/app/frontend/login.html
+++ b/app/frontend/login.html
@@ -2283,7 +2283,7 @@ function selectCalendarDay(dateStr) {
   ordersOnDay.forEach(order => {
     const status = order.status || 'RICEVUTO';
     const statusColor = status === 'SPEDITO' ? '#22c55e' : '#f59e0b';
-    const statusText = status === 'COMPLETATO' ? '✓ Completato' : status === 'PARZIALE' ? '⚠ Parziale' : '⏳ In Lavorazione';
+    const statusText = ['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(status) ? '✓ Completato' : status === 'PARZIALE' ? '⚠ Parziale' : '⏳ In Lavorazione';
     const cliente = order.cliente || 'Cliente N/A';
 
     html += `

--- a/app/frontend/officina.html
+++ b/app/frontend/officina.html
@@ -2448,8 +2448,8 @@ function renderCards() {
 
   // Tutti vedono gli ordini LASER come read-only (gestiti da buildLaserReadOnlyBody)
   const visibleOrders = allOrders;
-  const activeOrders = visibleOrders.filter(o => o.status !== 'COMPLETATO');
-  const completedOrders = visibleOrders.filter(o => o.status === 'COMPLETATO');
+  const activeOrders = visibleOrders.filter(o => !['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status));
+  const completedOrders = visibleOrders.filter(o => ['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status));
 
   // Conteggio ordini attivi (mostrato nel titolo sezione)
   const countText = activeOrders.length === 1 ? '1 ordine attivo' : activeOrders.length + ' ordini attivi';
@@ -3452,11 +3452,11 @@ let calOrders = [];
 
 const calFaseColors = {
   LASER: '#3b82f6', PIEGA: '#f59e0b', SALDATURA: '#ef4444',
-  PULIZIA: '#8b5cf6', COMPLETATO: '#22c55e', PARZIALE: '#f97316'
+  PULIZIA: '#8b5cf6', COMPLETATO: '#22c55e', DA_FATTURARE: '#0ea5e9', CHIUSO: '#22c55e', PARZIALE: '#f97316'
 };
 
 function getCalStatusColor(order) {
-  if (order.status === 'COMPLETATO') return '#22c55e';
+  if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status)) return '#22c55e';
   if (order.status === 'PARZIALE') return '#f97316';
   const today = new Date(); today.setHours(0,0,0,0);
   const consegna = new Date(order.data_consegna); consegna.setHours(0,0,0,0);
@@ -3467,7 +3467,7 @@ function getCalStatusColor(order) {
 }
 
 function calCalcProgress(order) {
-  if (order.status === 'COMPLETATO') return 100;
+  if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status)) return 100;
   if (order.status === 'PARZIALE') return 85;
   const map = { LASER: 10, PIEGA: 35, SALDATURA: 55, PULIZIA: 80, COMPLETATO: 100 };
   const base = map[order.fase_corrente] || 0;
@@ -3722,7 +3722,7 @@ function renderClientCards(clients) {
 
   list.innerHTML = clients.map(c => {
     const ordersForClient = allOrders.filter(o => o.cliente === c.client_name);
-    const activeOrders = ordersForClient.filter(o => o.status !== 'COMPLETATO');
+    const activeOrders = ordersForClient.filter(o => !['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(o.status));
     return `<div class="form-card" style="padding: 20px 24px; gap: 12px; cursor:pointer;">
       <div style="display:flex; justify-content:space-between; align-items:center;">
         <div style="font-size:15px; font-weight:700; color:var(--black);">${escapeHtml(c.client_name)}</div>
@@ -3758,7 +3758,7 @@ function buildPhaseTimeline(order) {
     let status = 'attesa';
     let label = 'In attesa';
     let dateStr = '—';
-    if (order.status === 'COMPLETATO' && !step) {
+    if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status) && !step) {
       status = 'non-necessaria';
       label = 'Non necessaria';
       dateStr = '';
@@ -3863,7 +3863,7 @@ function escapeHtml(str) {
 }
 
 function calculateProgress(order) {
-  if (order.status === 'COMPLETATO') return 100;
+  if (['COMPLETATO','DA_FATTURARE','CHIUSO'].includes(order.status)) return 100;
   if (order.status === 'PARZIALE') return 85;
   const steps = order.processing_steps || [];
   const anyStarted = steps.some(s => s.timestamp_inizio);


### PR DESCRIPTION
## Summary

- Nuovo flusso ordini: produzione completata → **DA_FATTURARE** → Elena chiude con DDT/fattura → **CHIUSO** → archivio
- Nuova tab "Ordini da Fatturare" nell'interfaccia di Elena con tabella espandibile, form DDT/fattura, salva bozza, conferma chiusura
- Ordini chiusi riapribili dall'archivio, dati DDT/fattura visibili in archivio
- Migrazione automatica DB: nuove colonne + ordini esistenti migrati

### Backend
- 7 nuove colonne Order model (DDT, fattura, chiusura)
- `FatturazioneManager` con 5 metodi CRUD
- 5 nuovi endpoint API con audit logging
- ArchiveManager aggiornato per filtrare `CHIUSO`
- KPI/Alert aggiornati per i nuovi stati

### Frontend
- Tab "Ordini da Fatturare" in `impiegata.html`: badge contatore, filtri (cliente, ordine, date), ordinamento, tabella espandibile con dettagli ordine + form DDT/fattura
- Archivio: colonne DDT/Fattura + bottone "Riapri Ordine"
- `officina.html`, `dettaglio-ordine.html`: aggiornati riferimenti status

## Test plan
- [ ] Verificare che ordini completati (PULIZIA → fine) vadano in stato DA_FATTURARE
- [ ] Verificare tab "Ordini da Fatturare" visibile per Elena con badge contatore
- [ ] Testare salvataggio bozza DDT/fattura
- [ ] Testare chiusura ordine con popup conferma → status CHIUSO
- [ ] Verificare che ordini CHIUSO appaiano in archivio con dati DDT/fattura
- [ ] Testare riapertura ordine dall'archivio → torna in DA_FATTURARE
- [ ] Verificare migrazione automatica colonne su DB esistente

https://claude.ai/code/session_016pJiQr735fyLgskVXSuWLY